### PR TITLE
[NUGUDI-35] 공용 tabs component 구현 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
     },
     "editor.defaultFormatter": "biomejs.biome",
     "editor.formatOnSave": true
-  }
+  },
+  "vitest.disableWorkspaceWarning": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,5 @@
     },
     "editor.defaultFormatter": "biomejs.biome",
     "editor.formatOnSave": true
-  },
-  "vitest.disableWorkspaceWarning": true
+  }
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import "@nugudi/themes/themes.css";
 import "@nugudi/react-components-layout/style.css";
 import "@nugudi/react-components-button/style.css";
 import "@nugudi/react-components-input/style.css";
+import "@nugudi/react-components-tab/style.css";
 
 const Pretendard = localFont({
   src: "../node_modules/pretendard/dist/web/variable/woff2/PretendardVariable.woff2",

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,18 +1,42 @@
+"use client";
+
 import { Emphasis, Heading } from "@nugudi/react-components-layout";
+import { Tabs } from "@nugudi/react-components-tab";
 import { ButtonContainer } from "./components/button-container";
 import InputContainer from "./components/input-container";
 
 export default function Home() {
   return (
-    <div>
-      <Heading as="h1" fontSize="h1" color="main">
-        Nugudi UI 컴포넌트 테스트
-      </Heading>
-      <Emphasis fontSize="e1" color="blackAlpha">
-        Emphasis
-      </Emphasis>
-      <ButtonContainer />
-      <InputContainer />
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        maxWidth: 600,
+        margin: "0 auto",
+      }}
+    >
+      <Tabs defaultValue="tab1">
+        <Tabs.List>
+          <Tabs.Item value="tab1">식당 정보</Tabs.Item>
+          <Tabs.Item value="tab2">리뷰</Tabs.Item>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">
+          <h3>첫 번째 탭 내용</h3>
+          <Heading as="h1" fontSize="h1" color="main">
+            Nugudi UI 컴포넌트 테스트
+          </Heading>
+          <Emphasis fontSize="e1" color="blackAlpha">
+            Emphasis
+          </Emphasis>
+          <ButtonContainer />
+        </Tabs.Panel>
+
+        <Tabs.Panel value="tab2">
+          <h3>두 번째 탭 내용</h3>
+          <InputContainer />
+        </Tabs.Panel>
+      </Tabs>
     </div>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@nugudi/react-components-button": "workspace:*",
     "@nugudi/react-components-input": "workspace:*",
     "@nugudi/react-components-layout": "workspace:*",
+    "@nugudi/react-components-tab": "workspace:*",
     "@nugudi/react-hooks-button": "workspace:*",
     "@nugudi/themes": "workspace:*",
     "@sentry/nextjs": "^9.31.0",

--- a/packages/react/components/tab/README.md
+++ b/packages/react/components/tab/README.md
@@ -19,7 +19,7 @@ import { Tabs } from "@nugudi/react-components-tab";
 
 const App = () => {
   return (
-    <Tabs defaultValue="tab1" size="full">
+    <Tabs defaultValue="tab1">
       <Tabs.List>
         <Tabs.Item value="tab1">식당 정보</Tabs.Item>
         <Tabs.Item value="tab2">리뷰</Tabs.Item>
@@ -47,10 +47,31 @@ const App = () => {
 };
 ```
 
+### 모바일 스와이프 지원
+
+기본적으로 모바일 스와이프와 자동 높이 조절이 지원됩니다.
+
+```tsx
+<Tabs defaultValue="tab1">
+  <Tabs.List>
+    <Tabs.Item value="tab1">정보</Tabs.Item>
+    <Tabs.Item value="tab2">리뷰</Tabs.Item>
+  </Tabs.List>
+
+  <Tabs.Panel value="tab1">
+    <div style={{ height: 200 }}>정보 컨텐츠</div>
+  </Tabs.Panel>
+
+  <Tabs.Panel value="tab2">
+    <div style={{ height: 400 }}>리뷰 컨텐츠</div>
+  </Tabs.Panel>
+</Tabs>
+```
+
 ## 접근성
 
 이 컴포넌트는 WAI-ARIA 가이드라인을 따릅니다:
 
 - `role="tablist"`, `role="tab"`, `role="tabpanel"` 속성 사용
-- `aria-selected`, `aria-disabled` 상태 관리
+- `aria-selected`, `aria-disabled`, `aria-controls`, `aria-labelledby` 상태 관리
 - 키보드 네비게이션 지원 (화살표 키)

--- a/packages/react/components/tab/README.md
+++ b/packages/react/components/tab/README.md
@@ -1,0 +1,56 @@
+# @nugudi/react-components-tab
+
+React Tab 컴포넌트 라이브러리입니다. 간단하고 유연한 API로 탭 인터페이스를 구현할 수 있습니다.
+
+## 설치
+
+```bash
+npm install @nugudi/react-components-tab
+```
+
+## 기본 사용법
+
+### 컴파운드 패턴
+
+간단하게 `defaultValue`만 설정하면 내부에서 상태를 관리합니다.
+
+```tsx
+import { Tabs } from "@nugudi/react-components-tab";
+
+const App = () => {
+  return (
+    <Tabs defaultValue="tab1" size="full">
+      <Tabs.List>
+        <Tabs.Item value="tab1">식당 정보</Tabs.Item>
+        <Tabs.Item value="tab2">리뷰</Tabs.Item>
+        <Tabs.Item value="tab3" disabled>
+          메뉴
+        </Tabs.Item>
+      </Tabs.List>
+
+      <Tabs.Panel value="tab1">
+        <h3>식당 정보</h3>
+        <p>식당의 기본 정보를 확인하세요.</p>
+      </Tabs.Panel>
+
+      <Tabs.Panel value="tab2">
+        <h3>리뷰</h3>
+        <p>다른 고객들의 리뷰를 읽어보세요.</p>
+      </Tabs.Panel>
+
+      <Tabs.Panel value="tab3">
+        <h3>메뉴</h3>
+        <p>메뉴 정보는 준비 중입니다.</p>
+      </Tabs.Panel>
+    </Tabs>
+  );
+};
+```
+
+## 접근성
+
+이 컴포넌트는 WAI-ARIA 가이드라인을 따릅니다:
+
+- `role="tablist"`, `role="tab"`, `role="tabpanel"` 속성 사용
+- `aria-selected`, `aria-disabled` 상태 관리
+- 키보드 네비게이션 지원 (화살표 키)

--- a/packages/react/components/tab/package.json
+++ b/packages/react/components/tab/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@nugudi/react-components-tab",
+  "version": "0.0.1",
+  "sideEffects": [
+    "**/*.css",
+    "./dist/index.css"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./style.css": "./dist/index.css"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "check-types": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
+  },
+  "dependencies": {
+    "@nugudi/themes": "workspace:*",
+    "@vanilla-extract/css": "^1.17.4",
+    "@vanilla-extract/recipes": "^0.5.7",
+    "clsx": "^2.1.1"
+  },
+  "devDependencies": {
+    "@tsconfig/vite-react": "^3.4.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vanilla-extract/vite-plugin": "^5.1.1",
+    "@vitejs/plugin-react": "^4.7.0",
+    "typescript": "^5.8.3",
+    "vite": "^6.0.7",
+    "vite-plugin-dts": "^4.5.2",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.3"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/react/components/tab/package.json
+++ b/packages/react/components/tab/package.json
@@ -30,7 +30,10 @@
     "@nugudi/themes": "workspace:*",
     "@vanilla-extract/css": "^1.17.4",
     "@vanilla-extract/recipes": "^0.5.7",
-    "clsx": "^2.1.1"
+    "clsx": "^2.1.1",
+    "embla-carousel": "^8.5.1",
+    "embla-carousel-auto-height": "^8.5.1",
+    "embla-carousel-react": "^8.5.1"
   },
   "devDependencies": {
     "@tsconfig/vite-react": "^3.4.0",

--- a/packages/react/components/tab/src/Tab.tsx
+++ b/packages/react/components/tab/src/Tab.tsx
@@ -1,0 +1,119 @@
+import { clsx } from "clsx";
+import * as React from "react";
+import {
+  tabListStyle,
+  tabPanelStyle,
+  tabStyle,
+  tabsContainerStyle,
+} from "./style.css";
+import { TabsProvider, useTabsContext } from "./TabsContext";
+import type { TabListProps, TabPanelProps, TabProps, TabsProps } from "./types";
+import { useTab, useTabPanel, useTabs } from "./useTab";
+
+const Tabs = ({
+  items = [],
+  children,
+  defaultValue,
+  size = "full",
+  className,
+  style,
+}: TabsProps) => {
+  const { value, onChange: handleChange } = useTabs({
+    defaultValue: defaultValue || items[0]?.id,
+  });
+
+  const contextValue = React.useMemo(
+    () => ({
+      value,
+      onChange: handleChange,
+      size,
+    }),
+    [value, handleChange, size],
+  );
+
+  return (
+    <TabsProvider value={contextValue}>
+      <div className={clsx(tabsContainerStyle, className)} style={style}>
+        {children ? (
+          children
+        ) : (
+          <>
+            <TabList>
+              {items.map((item) => (
+                <Tab key={item.id} value={item.id} disabled={item.disabled}>
+                  {item.label}
+                </Tab>
+              ))}
+            </TabList>
+            {items.map((item) => (
+              <TabPanel key={item.id} value={item.id}>
+                {item.content}
+              </TabPanel>
+            ))}
+          </>
+        )}
+      </div>
+    </TabsProvider>
+  );
+};
+
+const TabList = ({ children, className }: TabListProps) => {
+  return (
+    <div role="tablist" className={clsx(tabListStyle(), className)}>
+      {children}
+    </div>
+  );
+};
+
+const Tab = ({ value, children, disabled, className, onClick }: TabProps) => {
+  const { value: selectedValue, onChange, size } = useTabsContext();
+  const { tabProps, isSelected } = useTab(
+    { value, disabled, onClick },
+    selectedValue,
+    onChange,
+  );
+
+  return (
+    <button
+      {...tabProps}
+      type="button"
+      className={clsx(
+        tabStyle({
+          size,
+          isActive: isSelected,
+          disabled,
+        }),
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+};
+
+const TabPanel = ({ value, children, className }: TabPanelProps) => {
+  const { value: selectedValue } = useTabsContext();
+  const { tabPanelProps, isActive } = useTabPanel({ value }, selectedValue);
+
+  if (!isActive) return null;
+
+  return (
+    <div {...tabPanelProps} className={clsx(tabPanelStyle, className)}>
+      {children}
+    </div>
+  );
+};
+
+Tabs.displayName = "Tabs";
+TabList.displayName = "TabList";
+Tab.displayName = "Tab";
+TabPanel.displayName = "TabPanel";
+
+const TabsWithCompounds = Object.assign(Tabs, {
+  List: TabList,
+  Item: Tab,
+  Panel: TabPanel,
+});
+
+export { TabsWithCompounds as Tabs };
+export { TabList, Tab, TabPanel };

--- a/packages/react/components/tab/src/Tab.tsx
+++ b/packages/react/components/tab/src/Tab.tsx
@@ -1,57 +1,118 @@
 import { clsx } from "clsx";
-import * as React from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
+  carouselContainerStyle,
+  carouselViewportStyle,
   tabListStyle,
   tabPanelStyle,
   tabStyle,
   tabsContainerStyle,
 } from "./style.css";
+import {
+  TabsCarouselProvider,
+  useTabsCarouselContext,
+} from "./TabsCarouselContext";
 import { TabsProvider, useTabsContext } from "./TabsContext";
 import type { TabListProps, TabPanelProps, TabProps, TabsProps } from "./types";
 import { useTab, useTabPanel, useTabs } from "./useTab";
+import { useTabsCarousel } from "./useTabsCarousel";
 
-const Tabs = ({
-  items = [],
-  children,
-  defaultValue,
-  size = "full",
-  className,
-  style,
-}: TabsProps) => {
+const Tabs = ({ children, defaultValue, className, style }: TabsProps) => {
   const { value, onChange: handleChange } = useTabs({
-    defaultValue: defaultValue || items[0]?.id,
+    defaultValue,
   });
 
-  const contextValue = React.useMemo(
+  const [contentIndex, setContentIndex] = useState(0);
+
+  const valueToIndexMap = useRef(new Map<string, number>());
+  const indexToValueMap = useRef(new Map<number, string>());
+
+  useEffect(() => {
+    return () => {
+      valueToIndexMap.current.clear();
+      indexToValueMap.current.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    const index = valueToIndexMap.current.get(value);
+    if (index !== undefined && index !== contentIndex) {
+      setContentIndex(index);
+    }
+  }, [value, contentIndex]);
+
+  const handleSetContentIndex = useCallback(
+    (index: number) => {
+      setContentIndex(index);
+      const tabValue = indexToValueMap.current.get(index);
+      if (tabValue && tabValue !== value) {
+        handleChange(tabValue);
+      }
+    },
+    [value, handleChange],
+  );
+
+  const contextValue = useMemo(
     () => ({
       value,
       onChange: handleChange,
-      size,
+      contentIndex,
+      setContentIndex: handleSetContentIndex,
+      valueToIndexMap: valueToIndexMap.current,
+      indexToValueMap: indexToValueMap.current,
     }),
-    [value, handleChange, size],
+    [value, handleChange, contentIndex, handleSetContentIndex],
   );
+
+  const processChildren = (children: React.ReactNode): React.ReactNode => {
+    if (!children) return null;
+
+    const childrenArray = React.Children.toArray(children);
+    let tabListElement: React.ReactElement | null = null;
+    const tabPanelElements: React.ReactElement[] = [];
+    const otherElements: React.ReactNode[] = [];
+
+    childrenArray.forEach((child) => {
+      if (React.isValidElement(child)) {
+        if (
+          child.type === TabList ||
+          (child.type as React.ComponentType)?.displayName === "TabList"
+        ) {
+          tabListElement = child;
+        } else if (
+          child.type === TabPanel ||
+          (child.type as React.ComponentType)?.displayName === "TabPanel"
+        ) {
+          tabPanelElements.push(child);
+        } else {
+          otherElements.push(child);
+        }
+      } else {
+        otherElements.push(child);
+      }
+    });
+
+    return (
+      <>
+        {tabListElement}
+        {otherElements}
+        {tabPanelElements.length > 0 && (
+          <TabPanelContainer>{tabPanelElements}</TabPanelContainer>
+        )}
+      </>
+    );
+  };
 
   return (
     <TabsProvider value={contextValue}>
       <div className={clsx(tabsContainerStyle, className)} style={style}>
-        {children ? (
-          children
-        ) : (
-          <>
-            <TabList>
-              {items.map((item) => (
-                <Tab key={item.id} value={item.id} disabled={item.disabled}>
-                  {item.label}
-                </Tab>
-              ))}
-            </TabList>
-            {items.map((item) => (
-              <TabPanel key={item.id} value={item.id}>
-                {item.content}
-              </TabPanel>
-            ))}
-          </>
-        )}
+        {processChildren(children)}
       </div>
     </TabsProvider>
   );
@@ -66,7 +127,7 @@ const TabList = ({ children, className }: TabListProps) => {
 };
 
 const Tab = ({ value, children, disabled, className, onClick }: TabProps) => {
-  const { value: selectedValue, onChange, size } = useTabsContext();
+  const { value: selectedValue, onChange } = useTabsContext();
   const { tabProps, isSelected } = useTab(
     { value, disabled, onClick },
     selectedValue,
@@ -79,7 +140,6 @@ const Tab = ({ value, children, disabled, className, onClick }: TabProps) => {
       type="button"
       className={clsx(
         tabStyle({
-          size,
           isActive: isSelected,
           disabled,
         }),
@@ -91,11 +151,119 @@ const Tab = ({ value, children, disabled, className, onClick }: TabProps) => {
   );
 };
 
-const TabPanel = ({ value, children, className }: TabPanelProps) => {
-  const { value: selectedValue } = useTabsContext();
-  const { tabPanelProps, isActive } = useTabPanel({ value }, selectedValue);
+const TabPanelContainer = ({ children }: { children: React.ReactNode }) => {
+  const { valueToIndexMap, indexToValueMap } = useTabsContext();
+  const carouselState = useTabsCarousel();
 
-  if (!isActive) return null;
+  const registerPanel = useCallback(
+    (value: string) => {
+      // 이미 등록된 패널이면 기존 인덱스 반환
+      if (valueToIndexMap.has(value)) {
+        const existingIndex = valueToIndexMap.get(value);
+        if (existingIndex !== undefined) {
+          return existingIndex;
+        }
+      }
+
+      // 새 패널이면 다음 인덱스 할당
+      const index = valueToIndexMap.size;
+      valueToIndexMap.set(value, index);
+      indexToValueMap.set(index, value);
+      carouselState.updateTabIndex(value, index);
+      return index;
+    },
+    [valueToIndexMap, indexToValueMap, carouselState.updateTabIndex],
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      ...carouselState,
+      registerPanel,
+    }),
+    [carouselState, registerPanel],
+  );
+
+  useEffect(() => {
+    valueToIndexMap.clear();
+    indexToValueMap.clear();
+
+    // children을 미리 스캔해서 패널 순서 할당
+    if (children) {
+      const childrenArray = React.Children.toArray(children);
+      let panelIndex = 0;
+
+      const scanForPanels = (element: React.ReactNode) => {
+        if (React.isValidElement(element)) {
+          if (
+            element.type === TabPanel ||
+            (element.type as React.ComponentType)?.displayName === "TabPanel"
+          ) {
+            const panelValue = (element.props as Record<string, unknown>)
+              ?.value;
+            if (
+              typeof panelValue === "string" &&
+              !valueToIndexMap.has(panelValue)
+            ) {
+              valueToIndexMap.set(panelValue, panelIndex);
+              indexToValueMap.set(panelIndex, panelValue);
+              panelIndex++;
+            }
+          }
+          if ((element.props as Record<string, unknown>)?.children) {
+            React.Children.forEach(
+              (element.props as Record<string, unknown>)
+                .children as React.ReactNode,
+              scanForPanels,
+            );
+          }
+        }
+      };
+
+      childrenArray.forEach(scanForPanels);
+    }
+
+    return () => {
+      valueToIndexMap.clear();
+      indexToValueMap.clear();
+    };
+  }, [children, valueToIndexMap, indexToValueMap]);
+
+  return (
+    <TabsCarouselProvider value={contextValue}>
+      <div
+        className={carouselViewportStyle}
+        ref={carouselState.carouselRef}
+        {...carouselState.rootProps}
+      >
+        <div className={carouselContainerStyle}>{children}</div>
+      </div>
+    </TabsCarouselProvider>
+  );
+};
+
+interface TabPanelPropsWithIndex extends TabPanelProps {
+  index?: number;
+}
+
+const TabPanel = ({
+  value,
+  children,
+  className,
+  index,
+}: TabPanelPropsWithIndex) => {
+  const { value: selectedValue } = useTabsContext();
+  const { tabPanelProps } = useTabPanel({ value }, selectedValue);
+  const carouselContext = useTabsCarouselContext({ strict: false });
+
+  useEffect(() => {
+    if (index !== undefined) {
+      if (carouselContext) {
+        carouselContext.updateTabIndex(value, index);
+      }
+    } else if (carouselContext?.registerPanel) {
+      carouselContext.registerPanel(value);
+    }
+  }, [value, index, carouselContext]);
 
   return (
     <div {...tabPanelProps} className={clsx(tabPanelStyle, className)}>

--- a/packages/react/components/tab/src/TabsCarouselContext.tsx
+++ b/packages/react/components/tab/src/TabsCarouselContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext } from "react";
+import type { UseTabsCarouselReturn } from "./useTabsCarousel";
+
+export interface UseTabsCarouselContext extends UseTabsCarouselReturn {
+  registerPanel: (value: string) => number;
+}
+
+const TabsCarouselContext = createContext<UseTabsCarouselContext | null>(null);
+
+export const TabsCarouselProvider = TabsCarouselContext.Provider;
+
+export function useTabsCarouselContext<T extends boolean | undefined = true>({
+  strict = true,
+}: {
+  strict?: T;
+} = {}): T extends false
+  ? UseTabsCarouselContext | null
+  : UseTabsCarouselContext {
+  const context = useContext(TabsCarouselContext);
+  if (!context && strict) {
+    throw new Error(
+      "useTabsCarouselContext must be used within a TabsCarousel",
+    );
+  }
+
+  return context as UseTabsCarouselContext;
+}

--- a/packages/react/components/tab/src/TabsContext.tsx
+++ b/packages/react/components/tab/src/TabsContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react";
+
+export interface UseTabsContext {
+  value: string;
+  onChange: (value: string) => void;
+  size: "full";
+}
+
+const TabsContext = createContext<UseTabsContext | null>(null);
+
+export const TabsProvider = TabsContext.Provider;
+
+export function useTabsContext<T extends boolean | undefined = true>({
+  strict = true,
+}: {
+  strict?: T;
+} = {}): T extends false ? UseTabsContext | null : UseTabsContext {
+  const context = useContext(TabsContext);
+
+  if (!context && strict) {
+    throw new Error("useTabsContext must be used within a Tabs");
+  }
+
+  return context as UseTabsContext;
+}

--- a/packages/react/components/tab/src/TabsContext.tsx
+++ b/packages/react/components/tab/src/TabsContext.tsx
@@ -3,7 +3,10 @@ import { createContext, useContext } from "react";
 export interface UseTabsContext {
   value: string;
   onChange: (value: string) => void;
-  size: "full";
+  contentIndex: number;
+  setContentIndex: (index: number) => void;
+  valueToIndexMap: Map<string, number>;
+  indexToValueMap: Map<number, string>;
 }
 
 const TabsContext = createContext<UseTabsContext | null>(null);

--- a/packages/react/components/tab/src/index.ts
+++ b/packages/react/components/tab/src/index.ts
@@ -1,0 +1,14 @@
+export { Tabs } from "./Tab";
+export { TabsProvider, useTabsContext } from "./TabsContext";
+export type {
+  TabItem,
+  TabListProps,
+  TabPanelProps,
+  TabProps,
+  TabsProps,
+  UseTabPanelProps,
+  UseTabPanelReturn,
+  UseTabsProps,
+  UseTabsReturn,
+} from "./types";
+export { useTab, useTabPanel, useTabs } from "./useTab";

--- a/packages/react/components/tab/src/index.ts
+++ b/packages/react/components/tab/src/index.ts
@@ -1,7 +1,6 @@
 export { Tabs } from "./Tab";
 export { TabsProvider, useTabsContext } from "./TabsContext";
 export type {
-  TabItem,
   TabListProps,
   TabPanelProps,
   TabProps,

--- a/packages/react/components/tab/src/style.css.ts
+++ b/packages/react/components/tab/src/style.css.ts
@@ -1,5 +1,5 @@
 import { classes, vars } from "@nugudi/themes";
-import { keyframes, style } from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
 export const tabsContainerStyle = style({
@@ -46,11 +46,6 @@ export const tabStyle = recipe({
     },
   },
   variants: {
-    size: {
-      full: {
-        padding: "0.75rem",
-      },
-    },
     isActive: {
       true: {
         color: vars.colors.$scale.zinc[600],
@@ -71,18 +66,35 @@ export const tabStyle = recipe({
   },
 });
 
-const tabPanelFadeIn = keyframes({
-  "0%": {
-    opacity: 0,
-    transform: "translateY(8px)",
-  },
-  "100%": {
-    opacity: 1,
-    transform: "translateY(0)",
-  },
-});
-
 export const tabPanelStyle = style({
   padding: "8px 16px",
-  animation: `${tabPanelFadeIn} 0.2s ease-out forwards`,
+  flexShrink: 0,
+  width: "100%",
+  minHeight: 0,
+  boxSizing: "border-box",
+});
+
+export const carouselViewportStyle = style({
+  overflow: "hidden",
+  width: "100%",
+  touchAction: "manipulation",
+  WebkitOverflowScrolling: "touch",
+});
+
+export const carouselContainerStyle = style({
+  display: "flex",
+  transition: "height 300ms ease",
+  backfaceVisibility: "hidden",
+  touchAction: "manipulation",
+  // 드래그 가능하도록 설정
+  userSelect: "none",
+  WebkitUserSelect: "none",
+  MozUserSelect: "none",
+  msUserSelect: "none",
+  cursor: "grab",
+  // iOS Safari 호환성
+  WebkitOverflowScrolling: "touch",
+  ":active": {
+    cursor: "grabbing",
+  },
 });

--- a/packages/react/components/tab/src/style.css.ts
+++ b/packages/react/components/tab/src/style.css.ts
@@ -1,0 +1,88 @@
+import { classes, vars } from "@nugudi/themes";
+import { keyframes, style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
+
+export const tabsContainerStyle = style({
+  width: "100%",
+  WebkitTapHighlightColor: "transparent",
+});
+
+export const tabListStyle = recipe({
+  base: {
+    display: "flex",
+    position: "relative",
+  },
+});
+
+export const tabStyle = recipe({
+  base: {
+    padding: "12px 16px",
+    border: "none",
+    background: "transparent",
+    cursor: "pointer",
+    transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+    position: "relative",
+    whiteSpace: "nowrap",
+    outline: "none",
+    ...classes.typography.body.b3,
+    color: vars.colors.$scale.zinc[400],
+    borderBottom: `2px solid transparent`,
+    flex: 1,
+    textAlign: "center",
+    transform: "translateX(0)",
+
+    // 모바일 터치 하이라이트 제거
+    WebkitTapHighlightColor: "transparent",
+    WebkitTouchCallout: "none",
+    WebkitUserSelect: "none",
+    userSelect: "none",
+
+    // 모바일에서 버튼 스타일 제거
+    WebkitAppearance: "none",
+    appearance: "none",
+
+    ":hover": {
+      color: vars.colors.$scale.zinc[500],
+    },
+  },
+  variants: {
+    size: {
+      full: {
+        padding: "0.75rem",
+      },
+    },
+    isActive: {
+      true: {
+        color: vars.colors.$scale.zinc[600],
+        fontWeight: vars.typography.fontWeight[600],
+        borderBottom: `2px solid ${vars.colors.$scale.zinc[600]}`,
+        transform: "translateX(0) scale(1.02)",
+      },
+    },
+    disabled: {
+      true: {
+        cursor: "not-allowed",
+        color: vars.colors.$scale.zinc[400],
+        ":hover": {
+          color: vars.colors.$scale.zinc[400],
+        },
+      },
+    },
+  },
+});
+
+const tabPanelFadeIn = keyframes({
+  "0%": {
+    opacity: 0,
+    transform: "translateY(8px)",
+  },
+  "100%": {
+    opacity: 1,
+    transform: "translateY(0)",
+  },
+});
+
+export const tabPanelStyle = style({
+  padding: "8px 16px",
+  animation: `${tabPanelFadeIn} 0.2s ease-out forwards`,
+});

--- a/packages/react/components/tab/src/types.ts
+++ b/packages/react/components/tab/src/types.ts
@@ -55,8 +55,10 @@ export interface UseTabProps {
 export interface UseTabReturn {
   tabProps: {
     role: "tab";
+    id: string;
     "aria-selected": boolean;
     "aria-disabled"?: boolean;
+    "aria-controls": string;
     tabIndex: number;
     onKeyDown: (event: React.KeyboardEvent) => void;
     onClick: () => void;
@@ -71,6 +73,8 @@ export interface UseTabPanelProps {
 export interface UseTabPanelReturn {
   tabPanelProps: {
     role: "tabpanel";
+    id: string;
+    "aria-labelledby": string;
     tabIndex: number;
   };
   isActive: boolean;

--- a/packages/react/components/tab/src/types.ts
+++ b/packages/react/components/tab/src/types.ts
@@ -1,0 +1,77 @@
+import type * as React from "react";
+
+export interface TabItem {
+  id: string;
+  label: string;
+  content?: React.ReactNode;
+  disabled?: boolean;
+}
+
+export interface TabsProps {
+  items?: TabItem[];
+  children?: React.ReactNode;
+  defaultValue?: string;
+  size?: "full";
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export interface TabListProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export interface TabProps {
+  value: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+  className?: string;
+  onClick?: () => void;
+}
+
+export interface TabPanelProps {
+  value: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+// Hook Types
+export interface UseTabsProps {
+  defaultValue?: string;
+}
+
+export interface UseTabsReturn {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export interface UseTabProps {
+  value: string;
+  disabled?: boolean;
+  onKeyDown?: (event: React.KeyboardEvent) => void;
+  onClick?: () => void;
+}
+
+export interface UseTabReturn {
+  tabProps: {
+    role: "tab";
+    "aria-selected": boolean;
+    "aria-disabled"?: boolean;
+    tabIndex: number;
+    onKeyDown: (event: React.KeyboardEvent) => void;
+    onClick: () => void;
+  };
+  isSelected: boolean;
+}
+
+export interface UseTabPanelProps {
+  value: string;
+}
+
+export interface UseTabPanelReturn {
+  tabPanelProps: {
+    role: "tabpanel";
+    tabIndex: number;
+  };
+  isActive: boolean;
+}

--- a/packages/react/components/tab/src/types.ts
+++ b/packages/react/components/tab/src/types.ts
@@ -1,17 +1,8 @@
 import type * as React from "react";
 
-export interface TabItem {
-  id: string;
-  label: string;
-  content?: React.ReactNode;
-  disabled?: boolean;
-}
-
 export interface TabsProps {
-  items?: TabItem[];
-  children?: React.ReactNode;
+  children: React.ReactNode;
   defaultValue?: string;
-  size?: "full";
   className?: string;
   style?: React.CSSProperties;
 }

--- a/packages/react/components/tab/src/useTab.ts
+++ b/packages/react/components/tab/src/useTab.ts
@@ -26,10 +26,14 @@ export const useTab = (
   const { value, disabled, onKeyDown, onClick } = props;
   const isSelected = selectedValue === value;
 
+  // 고유 ID 생성
+  const tabId = `tab-${value}`;
+  const panelId = `panel-${value}`;
+
   const handleClick = React.useCallback(() => {
     if (!disabled) {
-      onChange(value);
       onClick?.();
+      onChange(value);
     }
   }, [disabled, onChange, value, onClick]);
 
@@ -73,13 +77,15 @@ export const useTab = (
   const tabProps = React.useMemo(
     () => ({
       role: "tab" as const,
+      id: tabId,
       "aria-selected": isSelected,
       "aria-disabled": disabled,
+      "aria-controls": panelId,
       tabIndex: isSelected ? 0 : -1,
       onKeyDown: handleKeyDown,
       onClick: handleClick,
     }),
-    [isSelected, disabled, handleKeyDown, handleClick],
+    [tabId, panelId, isSelected, disabled, handleKeyDown, handleClick],
   );
 
   return {
@@ -95,12 +101,18 @@ export const useTabPanel = (
   const { value } = props;
   const isActive = selectedValue === value;
 
+  // 고유 ID 생성 (탭과 일치)
+  const tabId = `tab-${value}`;
+  const panelId = `panel-${value}`;
+
   const tabPanelProps = React.useMemo(
     () => ({
       role: "tabpanel" as const,
+      id: panelId,
+      "aria-labelledby": tabId,
       tabIndex: 0,
     }),
-    [],
+    [panelId, tabId],
   );
 
   return {

--- a/packages/react/components/tab/src/useTab.ts
+++ b/packages/react/components/tab/src/useTab.ts
@@ -1,0 +1,110 @@
+import * as React from "react";
+import type {
+  UseTabPanelProps,
+  UseTabPanelReturn,
+  UseTabProps,
+  UseTabReturn,
+  UseTabsProps,
+  UseTabsReturn,
+} from "./types";
+
+export const useTabs = (props: UseTabsProps): UseTabsReturn => {
+  const { defaultValue } = props;
+  const [value, setValue] = React.useState(defaultValue || "");
+
+  return {
+    value,
+    onChange: setValue,
+  };
+};
+
+export const useTab = (
+  props: UseTabProps,
+  selectedValue: string,
+  onChange: (value: string) => void,
+): UseTabReturn => {
+  const { value, disabled, onKeyDown, onClick } = props;
+  const isSelected = selectedValue === value;
+
+  const handleClick = React.useCallback(() => {
+    if (!disabled) {
+      onChange(value);
+      onClick?.();
+    }
+  }, [disabled, onChange, value, onClick]);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      onKeyDown?.(event);
+
+      if (event.key === " " || event.key === "Enter") {
+        if (disabled) return;
+        if (event.defaultPrevented) return;
+
+        event.preventDefault();
+        handleClick();
+      }
+
+      if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+        const tabList = event.currentTarget.parentElement;
+        if (!tabList) return;
+
+        const tabs = Array.from(
+          tabList.querySelectorAll('[role="tab"]:not([aria-disabled="true"])'),
+        ) as HTMLElement[];
+
+        const currentIndex = tabs.indexOf(event.currentTarget as HTMLElement);
+        let nextIndex: number;
+
+        if (event.key === "ArrowLeft") {
+          nextIndex = currentIndex > 0 ? currentIndex - 1 : tabs.length - 1;
+        } else {
+          nextIndex = currentIndex < tabs.length - 1 ? currentIndex + 1 : 0;
+        }
+
+        tabs[nextIndex]?.focus();
+        tabs[nextIndex]?.click();
+      }
+    },
+    [onKeyDown, disabled, handleClick],
+  );
+
+  // 탭 버튼에 적용할 모든 props (접근성 포함)
+  const tabProps = React.useMemo(
+    () => ({
+      role: "tab" as const,
+      "aria-selected": isSelected,
+      "aria-disabled": disabled,
+      tabIndex: isSelected ? 0 : -1,
+      onKeyDown: handleKeyDown,
+      onClick: handleClick,
+    }),
+    [isSelected, disabled, handleKeyDown, handleClick],
+  );
+
+  return {
+    tabProps,
+    isSelected,
+  };
+};
+
+export const useTabPanel = (
+  props: UseTabPanelProps,
+  selectedValue: string,
+): UseTabPanelReturn => {
+  const { value } = props;
+  const isActive = selectedValue === value;
+
+  const tabPanelProps = React.useMemo(
+    () => ({
+      role: "tabpanel" as const,
+      tabIndex: 0,
+    }),
+    [],
+  );
+
+  return {
+    tabPanelProps,
+    isActive,
+  };
+};

--- a/packages/react/components/tab/src/useTabsCarousel.ts
+++ b/packages/react/components/tab/src/useTabsCarousel.ts
@@ -1,0 +1,107 @@
+import AutoHeight from "embla-carousel-auto-height";
+import useEmblaCarousel from "embla-carousel-react";
+import { useCallback, useEffect, useRef } from "react";
+import { useTabsContext } from "./TabsContext";
+
+export interface UseTabsCarouselProps {
+  loop?: boolean;
+  dragThreshold?: number;
+  onSettle?: () => void;
+}
+
+export interface UseTabsCarouselReturn {
+  carouselRef: ((node: HTMLDivElement | null) => void) | undefined;
+  updateTabIndex: (value: string, index: number) => void;
+  rootProps: Record<string, any>;
+}
+
+const autoHeight = AutoHeight();
+const plugins = [autoHeight];
+
+export const useTabsCarousel = (
+  props: UseTabsCarouselProps = {},
+): UseTabsCarouselReturn => {
+  const api = useTabsContext({ strict: false });
+  const isInitialScroll = useRef(true);
+
+  const [emblaRef, emblaApi] = useEmblaCarousel(
+    {
+      loop: props.loop,
+      dragThreshold: props.dragThreshold || 5,
+      duration: 20,
+      watchDrag: true,
+      axis: "x",
+      dragFree: false,
+      containScroll: "trimSnaps",
+      skipSnaps: false,
+      startIndex: 0,
+    },
+    plugins,
+  );
+
+  // embla select 이벤트 처리
+  useEffect(() => {
+    if (!emblaApi || !api) return;
+
+    const onSelect = () => {
+      const contentIndex = emblaApi.selectedScrollSnap();
+      api.setContentIndex(contentIndex);
+    };
+
+    const onSettle = () => {
+      props.onSettle?.();
+    };
+
+    const onPointerDown = () => {};
+
+    emblaApi.on("select", onSelect);
+    emblaApi.on("settle", onSettle);
+    emblaApi.on("pointerDown", onPointerDown);
+
+    return () => {
+      emblaApi.off("select", onSelect);
+      emblaApi.off("settle", onSettle);
+      emblaApi.off("pointerDown", onPointerDown);
+    };
+  }, [emblaApi, api, props.onSettle]);
+
+  useEffect(() => {
+    if (emblaApi && api && api.contentIndex !== emblaApi.selectedScrollSnap()) {
+      const engine = emblaApi.internalEngine();
+
+      // biome-ignore lint/correctness/useHookAtTopLevel: This is not a React Hook
+      engine.scrollBody.useDuration(4).useFriction(0.4);
+      engine.scrollTo.index(api.contentIndex, 0);
+
+      if (isInitialScroll.current) {
+        isInitialScroll.current = false;
+      }
+    }
+  }, [emblaApi, api]);
+
+  const updateTabIndex = useCallback(
+    (tabValue: string, index: number) => {
+      if (api && tabValue === api.value) {
+        api.setContentIndex(index);
+      }
+    },
+    [api],
+  );
+
+  if (!api) {
+    return {
+      carouselRef: undefined,
+      updateTabIndex: () => {},
+      rootProps: {},
+    };
+  }
+
+  return {
+    carouselRef: emblaRef,
+    updateTabIndex,
+    rootProps: {
+      "data-carousel": "",
+      "data-auto-height": "",
+    },
+  };
+};

--- a/packages/react/components/tab/src/useTabsCarousel.ts
+++ b/packages/react/components/tab/src/useTabsCarousel.ts
@@ -1,6 +1,6 @@
 import AutoHeight from "embla-carousel-auto-height";
 import useEmblaCarousel from "embla-carousel-react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTabsContext } from "./TabsContext";
 
 export interface UseTabsCarouselProps {
@@ -12,17 +12,16 @@ export interface UseTabsCarouselProps {
 export interface UseTabsCarouselReturn {
   carouselRef: ((node: HTMLDivElement | null) => void) | undefined;
   updateTabIndex: (value: string, index: number) => void;
-  rootProps: Record<string, any>;
+  rootProps: Record<string, unknown>;
 }
-
-const autoHeight = AutoHeight();
-const plugins = [autoHeight];
 
 export const useTabsCarousel = (
   props: UseTabsCarouselProps = {},
 ): UseTabsCarouselReturn => {
   const api = useTabsContext({ strict: false });
   const isInitialScroll = useRef(true);
+
+  const plugins = useMemo(() => [AutoHeight()], []);
 
   const [emblaRef, emblaApi] = useEmblaCarousel(
     {
@@ -67,11 +66,7 @@ export const useTabsCarousel = (
 
   useEffect(() => {
     if (emblaApi && api && api.contentIndex !== emblaApi.selectedScrollSnap()) {
-      const engine = emblaApi.internalEngine();
-
-      // biome-ignore lint/correctness/useHookAtTopLevel: This is not a React Hook
-      engine.scrollBody.useDuration(4).useFriction(0.4);
-      engine.scrollTo.index(api.contentIndex, 0);
+      emblaApi.scrollTo(api.contentIndex);
 
       if (isInitialScroll.current) {
         isInitialScroll.current = false;

--- a/packages/react/components/tab/tsconfig.json
+++ b/packages/react/components/tab/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@tsconfig/vite-react/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "./global.d.ts",
+    "vite.config.mts",
+    "vitest.config.mts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/packages/react/components/tab/vite.config.mts
+++ b/packages/react/components/tab/vite.config.mts
@@ -1,0 +1,56 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+const _filename = fileURLToPath(import.meta.url);
+const _dirname = dirname(_filename);
+
+export default defineConfig({
+  plugins: [
+    react(),
+    vanillaExtractPlugin(),
+    dts({
+      include: ["src"],
+      exclude: ["src/**/*.stories.tsx", "src/**/*.test.tsx"],
+      outDir: "dist",
+      entryRoot: "src",
+      insertTypesEntry: true,
+      rollupTypes: false,
+      tsconfigPath: "./tsconfig.json",
+    }),
+    tsconfigPaths(),
+  ],
+  build: {
+    lib: {
+      entry: resolve(_dirname, "src/index.ts"),
+      fileName: "index",
+      formats: ["es"],
+    },
+    rollupOptions: {
+      external: [
+        "react",
+        "react-dom",
+        "react/jsx-runtime",
+        "@vanilla-extract/css",
+      ],
+      output: {
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name?.endsWith('.css')) return "index.css";
+          return assetInfo.name || "assets/[name].[ext]";
+        },
+      },
+    },
+    sourcemap: true,
+    minify: false,
+    outDir: "dist",
+  },
+  resolve: {
+    alias: {
+      "@": resolve(_dirname, "./src"),
+    },
+  },
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,7 @@
     "@nugudi/react-components-button": "workspace:*",
     "@nugudi/react-components-input": "workspace:*",
     "@nugudi/react-components-layout": "workspace:*",
+    "@nugudi/react-components-tab": "workspace:*",
     "@nugudi/react-hooks-button": "workspace:*",
     "@nugudi/themes": "workspace:*",
     "@vanilla-extract/css": "^1.17.4",

--- a/packages/ui/src/ReactComponents/Tab.stories.tsx
+++ b/packages/ui/src/ReactComponents/Tab.stories.tsx
@@ -1,0 +1,102 @@
+import "@nugudi/react-components-tab/style.css";
+import { Tabs } from "@nugudi/react-components-tab";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof Tabs> = {
+  title: "Components/Tab",
+  component: Tabs,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          minHeight: 400,
+          maxWidth: 600,
+          margin: "0 auto",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      options: ["full"],
+      control: "select",
+      defaultValue: "full",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const TabStory: Story = {
+  render: () => (
+    <Tabs defaultValue="tab1" size="full">
+      <Tabs.List>
+        <Tabs.Item value="tab1">식당 정보</Tabs.Item>
+        <Tabs.Item value="tab2">리뷰</Tabs.Item>
+        <Tabs.Item value="tab3">메뉴</Tabs.Item>
+      </Tabs.List>
+
+      <Tabs.Panel value="tab1">
+        <ul>
+          <li>영업시간: 오전 10시 - 오후 2시</li>
+          <li>전화번호: 02-1234-5678</li>
+          <li>주소: 천안 너구리</li>
+        </ul>
+      </Tabs.Panel>
+
+      <Tabs.Panel value="tab2">
+        <div style={{ marginTop: "16px" }}>
+          <div
+            style={{
+              marginBottom: "12px",
+              padding: "8px",
+              backgroundColor: "#f5f5f5",
+              borderRadius: "4px",
+            }}
+          >
+            <strong>안애옹</strong> ⭐⭐⭐⭐⭐
+            <br />
+            떡볶이가 최고에요 !
+          </div>
+        </div>
+      </Tabs.Panel>
+
+      <Tabs.Panel value="tab3">
+        <ul>
+          <li>김치찌개 - 8,000원</li>
+          <li>떡볶이 - 7,000원</li>
+          <li>불고기 - 12,000원</li>
+          <li>마라탕 - 9,000원</li>
+        </ul>
+      </Tabs.Panel>
+    </Tabs>
+  ),
+};
+
+export const DisabledTabStory: Story = {
+  render: () => (
+    <Tabs defaultValue="info" size="full">
+      <Tabs.List>
+        <Tabs.Item value="info">정보</Tabs.Item>
+        <Tabs.Item value="menu" disabled>
+          메뉴 (준비중)
+        </Tabs.Item>
+      </Tabs.List>
+
+      <Tabs.Panel value="info">
+        <p>기본 정보가 여기에 표시됩니다.</p>
+      </Tabs.Panel>
+
+      <Tabs.Panel value="menu">
+        <p>메뉴 정보는 준비 중입니다.</p>
+      </Tabs.Panel>
+    </Tabs>
+  ),
+};

--- a/packages/ui/src/ReactComponents/Tab.stories.tsx
+++ b/packages/ui/src/ReactComponents/Tab.stories.tsx
@@ -21,13 +21,6 @@ const meta: Meta<typeof Tabs> = {
     ),
   ],
   tags: ["autodocs"],
-  argTypes: {
-    size: {
-      options: ["full"],
-      control: "select",
-      defaultValue: "full",
-    },
-  },
 };
 
 export default meta;
@@ -36,7 +29,7 @@ type Story = StoryObj<typeof meta>;
 
 export const TabStory: Story = {
   render: () => (
-    <Tabs defaultValue="tab1" size="full">
+    <Tabs defaultValue="tab1">
       <Tabs.List>
         <Tabs.Item value="tab1">식당 정보</Tabs.Item>
         <Tabs.Item value="tab2">리뷰</Tabs.Item>
@@ -82,7 +75,7 @@ export const TabStory: Story = {
 
 export const DisabledTabStory: Story = {
   render: () => (
-    <Tabs defaultValue="info" size="full">
+    <Tabs defaultValue="info">
       <Tabs.List>
         <Tabs.Item value="info">정보</Tabs.Item>
         <Tabs.Item value="menu" disabled>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@nugudi/react-components-layout':
         specifier: workspace:*
         version: link:../../packages/react/components/layout
+      '@nugudi/react-components-tab':
+        specifier: workspace:*
+        version: link:../../packages/react/components/tab
       '@nugudi/react-hooks-button':
         specifier: workspace:*
         version: link:../../packages/react/hooks/button
@@ -362,6 +365,58 @@ importers:
         specifier: ^3.2.3
         version: 3.2.4(@types/node@24.1.0)(@vitest/browser@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
+  packages/react/components/tab:
+    dependencies:
+      '@nugudi/themes':
+        specifier: workspace:*
+        version: link:../../../themes
+      '@vanilla-extract/css':
+        specifier: ^1.17.4
+        version: 1.17.4
+      '@vanilla-extract/recipes':
+        specifier: ^0.5.7
+        version: 0.5.7(@vanilla-extract/css@1.17.4)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      react:
+        specifier: ^19.0.0
+        version: 19.1.1
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.1(react@19.1.1)
+    devDependencies:
+      '@tsconfig/vite-react':
+        specifier: ^3.4.0
+        version: 3.4.0
+      '@types/react':
+        specifier: ^19
+        version: 19.1.9
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.1.7(@types/react@19.1.9)
+      '@vanilla-extract/vite-plugin':
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^6.0.7
+        version: 6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite-plugin-dts:
+        specifier: ^4.5.2
+        version: 4.5.4(@types/node@24.1.0)(rollup@4.46.2)(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      vitest:
+        specifier: ^3.2.3
+        version: 3.2.4(@types/node@24.1.0)(@vitest/browser@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+
   packages/react/hooks/button:
     dependencies:
       '@nugudi/react-hooks-toggle':
@@ -438,6 +493,9 @@ importers:
       '@nugudi/react-components-layout':
         specifier: workspace:*
         version: link:../react/components/layout
+      '@nugudi/react-components-tab':
+        specifier: workspace:*
+        version: link:../react/components/tab
       '@nugudi/react-hooks-button':
         specifier: workspace:*
         version: link:../react/hooks/button

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,6 +379,15 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      embla-carousel:
+        specifier: ^8.5.1
+        version: 8.6.0
+      embla-carousel-auto-height:
+        specifier: ^8.5.1
+        version: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-react:
+        specifier: ^8.5.1
+        version: 8.6.0(react@19.1.1)
       react:
         specifier: ^19.0.0
         version: 19.1.1
@@ -3581,6 +3590,24 @@ packages:
 
   electron-to-chromium@1.5.193:
     resolution: {integrity: sha512-eePuBZXM9OVCwfYUhd2OzESeNGnWmLyeu0XAEjf7xjijNjHFdeJSzuRUGN4ueT2tEYo5YqjHramKEFxz67p3XA==}
+
+  embla-carousel-auto-height@8.6.0:
+    resolution: {integrity: sha512-/HrJQOEM6aol/oF33gd2QlINcXy3e19fJWvHDuHWp2bpyTa+2dm9tVVJak30m2Qy6QyQ6Fc8DkImtv7pxWOJUQ==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-react@8.6.0:
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -9442,6 +9469,22 @@ snapshots:
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.193: {}
+
+  embla-carousel-auto-height@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-react@8.6.0(react@19.1.1):
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 19.1.1
+
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0: {}
 
   emoji-regex@10.4.0: {}
 


### PR DESCRIPTION
## 🌀 Issue Number

<!-- #이슈번호 -->

- #38 

## 🥳 To-Be

<!-- 변경 사항 -->

- package/react tab 컴포넌트 useTab 
- package/ui tab 스토리북 
- app/webs 예시 추가 (임시로 page 자체에 use client 추가)

## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)

## 👾 Additional Description (Optional)

**해결하지 않은 부분**
1. 모바일에서 손으로 스크롤 시 넘어가게하는 부분 
2. 슬라이딩 되는 애니메이션 

이 두 부분을 어떤 식으로 해결하는 것이 좋을지 고민중입니다. 
두 부분은 tab과 관련이 있긴하지만, 모바일 특성상 전체적으로 생각해야할 부분 인 것 같아 
다른 이슈에서 추가 후 (공용 훅?) tab에도 추가하는 방식을 생각중입니다. 

<img width="500" height="325" alt="스크린샷 2025-08-03 00 35 37" src="https://github.com/user-attachments/assets/585e17be-ca73-415c-bc26-19e5a743ef02" />

https://github.com/user-attachments/assets/2447587f-02d8-4fc4-9b40-1daae629f916



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * 새로운 탭(Tab) 컴포넌트가 추가되어, 탭 인터페이스를 통해 여러 정보를 분리하여 볼 수 있습니다.
  * 웹 페이지에 "식당 정보"와 "리뷰"를 탭으로 구분하여 사용할 수 있습니다.
  * Storybook에서 탭 컴포넌트의 다양한 사용 예시와 비활성화(Disabled) 탭 사례가 추가되었습니다.
  * 탭 컴포넌트에 키보드 내비게이션, 모바일 스와이프, 자동 높이 조절 기능이 포함되었습니다.

* **Documentation**
  * 탭 컴포넌트의 설치, 사용법, 접근성 및 예시가 포함된 README 문서가 추가되었습니다.

* **Chores**
  * 관련 패키지와 의존성 추가 및 빌드/테스트 환경이 구성되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->