### PR TITLE
[NUGUDI-43] 공용 Box 컴포넌트 생성

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
     },
     "editor.defaultFormatter": "biomejs.biome",
     "editor.formatOnSave": true
-  }
+  },
+  "vitest.disableWorkspaceWarning": true
 }

--- a/apps/web/app/page.css.ts
+++ b/apps/web/app/page.css.ts
@@ -2,9 +2,9 @@ import { vars } from "@nugudi/themes";
 import { style } from "@vanilla-extract/css";
 
 export const container = style({
-  minHeight: "100vh",
-  padding: "2rem",
-  backgroundColor: vars.colors.$scale.zinc[50],
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
 });
 
 export const section = style({

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,20 +1,14 @@
 "use client";
 
-import { Emphasis, Heading } from "@nugudi/react-components-layout";
+import { Box, Emphasis, Heading } from "@nugudi/react-components-layout";
 import { Tabs } from "@nugudi/react-components-tab";
 import { ButtonContainer } from "./components/button-container";
 import InputContainer from "./components/input-container";
+import * as styles from "./page.css";
 
 export default function Home() {
   return (
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        maxWidth: 600,
-        margin: "0 auto",
-      }}
-    >
+    <div>
       <Tabs defaultValue="tab1">
         <Tabs.List>
           <Tabs.Item value="tab1">식당 정보</Tabs.Item>
@@ -23,18 +17,28 @@ export default function Home() {
 
         <Tabs.Panel value="tab1">
           <h3>첫 번째 탭 내용</h3>
-          <Heading as="h1" fontSize="h1" color="main">
-            Nugudi UI 컴포넌트 테스트
-          </Heading>
-          <Emphasis fontSize="e1" color="blackAlpha">
-            Emphasis
-          </Emphasis>
+          <Box
+            background="main"
+            padding={10}
+            borderRadius="full"
+            color="whiteAlpha"
+          >
+            <Heading as="h1" fontSize="h1" color="whiteAlpha">
+              Nugudi UI 컴포넌트 테스트
+            </Heading>
+            <Emphasis fontSize="e1" color="whiteAlpha">
+              Emphasis
+            </Emphasis>
+          </Box>
+
           <ButtonContainer />
         </Tabs.Panel>
 
         <Tabs.Panel value="tab2">
-          <h3>두 번째 탭 내용</h3>
-          <InputContainer />
+          <div className={styles.container}>
+            <h3>두 번째 탭 내용</h3>
+            <InputContainer />
+          </div>
         </Tabs.Panel>
       </Tabs>
     </div>

--- a/packages/react/components/layout/src/core/types.ts
+++ b/packages/react/components/layout/src/core/types.ts
@@ -1,6 +1,6 @@
 import type { vars } from "@nugudi/themes";
 import type { JSX } from "react";
-import type { StyleSprinkles } from "@/core/style.css";
+import type { StyleSprinkles } from "./style.css";
 
 type AsProps = {
   as?: Exclude<keyof JSX.IntrinsicElements, keyof SVGElementTagNameMap>;

--- a/packages/react/components/layout/src/index.ts
+++ b/packages/react/components/layout/src/index.ts
@@ -1,3 +1,5 @@
+export type { BoxProps } from "./layout";
+export { Box } from "./layout";
 export type {
   BodyProps,
   EmphasisProps,

--- a/packages/react/components/layout/src/layout/Box.tsx
+++ b/packages/react/components/layout/src/layout/Box.tsx
@@ -19,7 +19,7 @@ const Box = (props: BoxProps, ref: React.Ref<HTMLDivElement>) => {
     ]),
     style: {
       color: color && vars.colors.$scale?.[color]?.[700],
-      background: background && vars.colors.$scale?.[background]?.[100],
+      background: background && vars.colors.$scale?.[background]?.[500],
       ...props.style,
     },
     children,

--- a/packages/react/components/layout/src/layout/Box.tsx
+++ b/packages/react/components/layout/src/layout/Box.tsx
@@ -1,29 +1,43 @@
 import { vars } from "@nugudi/themes";
-import clsx from "clsx";
-import React from "react";
-import { BaseStyle, StyleSprinkles } from "@/core/style.css";
-import type { BoxProps } from "@/layout/types";
-import { extractSprinkleProps } from "@/utils/properties";
+import { clsx } from "clsx";
+import * as React from "react";
+import { BaseStyle, StyleSprinkles } from "../core/style.css";
+import { extractSprinkleProps } from "../utils/properties";
+import type { BoxProps } from "./types";
 
-const Box = (props: BoxProps, ref: React.Ref<HTMLDivElement>) => {
-  const { as = "div", color, background, children } = props;
-  return React.createElement(as, {
-    ...props,
-    ref,
-    className: clsx([
-      BaseStyle,
-      StyleSprinkles(
-        extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
-      ),
-      props.className,
-    ]),
-    style: {
-      color: color && vars.colors.$scale?.[color]?.[700],
-      background: background && vars.colors.$scale?.[background]?.[500],
-      ...props.style,
+const Box = (props: BoxProps, ref: React.Ref<HTMLElement>) => {
+  const {
+    as = "div",
+    color,
+    background,
+    borderRadius,
+    padding,
+    children,
+    ...restProps
+  } = props;
+
+  return React.createElement(
+    as,
+    {
+      ...restProps,
+      ref,
+      className: clsx([
+        BaseStyle,
+        StyleSprinkles(
+          extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
+        ),
+        props.className,
+      ]),
+      style: {
+        color: color && vars.colors.$scale?.[color]?.[500],
+        background: background && vars.colors.$scale?.[background]?.[500],
+        borderRadius: borderRadius && vars.box.radii?.[borderRadius],
+        padding: padding && vars.box.spacing?.[padding],
+        ...props.style,
+      },
     },
     children,
-  });
+  );
 };
 
 const _Box = React.forwardRef(Box);

--- a/packages/react/components/layout/src/layout/Box.tsx
+++ b/packages/react/components/layout/src/layout/Box.tsx
@@ -1,0 +1,30 @@
+import { vars } from "@nugudi/themes";
+import clsx from "clsx";
+import React from "react";
+import { BaseStyle, StyleSprinkles } from "@/core/style.css";
+import type { BoxProps } from "@/layout/types";
+import { extractSprinkleProps } from "@/utils/properties";
+
+const Box = (props: BoxProps, ref: React.Ref<HTMLDivElement>) => {
+  const { as = "div", color, background, children } = props;
+  return React.createElement(as, {
+    ...props,
+    ref,
+    className: clsx([
+      BaseStyle,
+      StyleSprinkles(
+        extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
+      ),
+      props.className,
+    ]),
+    style: {
+      color: color && vars.colors.$scale?.[color]?.[700],
+      background: background && vars.colors.$scale?.[background]?.[100],
+      ...props.style,
+    },
+    children,
+  });
+};
+
+const _Box = React.forwardRef(Box);
+export { _Box as Box };

--- a/packages/react/components/layout/src/layout/index.ts
+++ b/packages/react/components/layout/src/layout/index.ts
@@ -1,0 +1,3 @@
+export { Box } from "./Box";
+
+export type { BoxProps } from "./types";

--- a/packages/react/components/layout/src/layout/types.ts
+++ b/packages/react/components/layout/src/layout/types.ts
@@ -1,0 +1,3 @@
+import type { AsElementProps, StyleProps } from "@/core/types";
+
+export type BoxProps = AsElementProps & StyleProps;

--- a/packages/ui/src/layout/Box.stories.tsx
+++ b/packages/ui/src/layout/Box.stories.tsx
@@ -1,0 +1,26 @@
+import "@nugudi/react-components-layout/style.css";
+import { Box as _Box } from "@nugudi/react-components-layout";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof _Box> = {
+  title: "Components/Layout/Box",
+  component: _Box,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const BoxStory: Story = {
+  args: {
+    as: "button",
+    padding: "5",
+    background: "main",
+    boxShadow: "xl",
+    borderRadius: "md",
+  },
+};

--- a/packages/ui/src/layout/Box.stories.tsx
+++ b/packages/ui/src/layout/Box.stories.tsx
@@ -1,5 +1,6 @@
 import "@nugudi/react-components-layout/style.css";
 import { Box as _Box } from "@nugudi/react-components-layout";
+import { vars } from "@nugudi/themes";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const meta: Meta<typeof _Box> = {
@@ -9,6 +10,24 @@ const meta: Meta<typeof _Box> = {
     layout: "centered",
   },
   tags: ["autodocs"],
+  argTypes: {
+    as: {
+      control: "select",
+      options: ["div"],
+    },
+    padding: {
+      control: "select",
+      options: Object.keys(vars.box.spacing),
+    },
+    borderRadius: {
+      control: "select",
+      options: Object.keys(vars.box.radii),
+    },
+    boxShadow: {
+      control: "select",
+      options: Object.keys(vars.box.shadows),
+    },
+  },
 };
 
 export default meta;
@@ -18,9 +37,10 @@ type Story = StoryObj<typeof meta>;
 export const BoxStory: Story = {
   args: {
     as: "button",
-    padding: "5",
+    padding: 10,
     background: "main",
     boxShadow: "xl",
     borderRadius: "md",
+    children: "YongCoding",
   },
 };


### PR DESCRIPTION
## 🌀 Issue Number

  - #44 

## 😵 As-Is

기초 레이아웃 및 스타일 유틸리티 컴포넌트인 `Box`를 도입하여, 다양한 UI 구성 요소들의 공통 스타일링 및 확장을 위한 기반 컴포넌트를 제공합니다.

## 🥳 To-Be

  - `Box` 컴포넌트를 구현하여 레이아웃 시스템의 기본 빌딩 블록 제공
  - 다양한 HTML 요소로 렌더링 가능한 `polymorphic 컴포넌트` 구현
  - 디자인 토큰 기반의 스타일 props 지원 (`color`, `background`, `borderRadius`, `padding`)
  - `Storybook`을 통한 컴포넌트 문서화 및 테스트 환경 구축

 ## ✅ Check List

  - [ ] 테스트가 전부 통과되었나요?
  - [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)
<img width="1181" height="961" alt="스크린샷 2025-08-03 오후 9 58 03" src="https://github.com/user-attachments/assets/230f892e-9d54-44d6-abaa-827741f3afa7" />

## 👾 Additional Description (Optional)

## 주요 변경사항

  - `packages/react/components/layout/src/layout/Box.tsx`: polymorphic Box 컴포넌트 구현
  - `packages/ui/src/layout/Box.stories.tsx`: Box 컴포넌트 스토리북 작성
  - `apps/web/app/page.tsx`: Box 컴포넌트를 활용한 페이지 레이아웃 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 새로운 Box 컴포넌트가 추가되어 다양한 스타일 속성 및 폴리모픽 렌더링(as prop)을 지원합니다.
  * Box 컴포넌트의 Storybook 스토리가 추가되어 다양한 속성 조합을 시각적으로 확인할 수 있습니다.
  * BoxProps 타입이 도입되어 Box 컴포넌트의 props를 명확하게 정의합니다.

* **Style**
  * 페이지 컨테이너의 CSS가 flex 레이아웃으로 변경되어 콘텐츠가 세로 중앙 정렬됩니다.
  * 주요 패널의 배경색, 패딩, 텍스트 색상이 개선되었습니다.

* **Chores**
  * Vitest 관련 워크스페이스 경고가 VSCode에서 비활성화되었습니다.

* **Documentation**
  * Box 컴포넌트에 대한 Storybook 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->