### PR TITLE
[NUGUDI-48] Chromatic error 수정 

### DIFF
--- a/packages/react/components/chip/vite.config.mts
+++ b/packages/react/components/chip/vite.config.mts
@@ -19,7 +19,7 @@ export default defineConfig({
       outDir: "dist",
       entryRoot: "src",
       insertTypesEntry: true,
-      rollupTypes: false,
+      rollupTypes: true,
       tsconfigPath: "./tsconfig.json",
     }),
     tsconfigPaths(),


### PR DESCRIPTION
## 🌀 Issue Number

<!-- #이슈번호 -->

- #52 

## 😵 As-Is

<!-- 문제 상황 정의 -->
<img width="345" height="140" alt="스크린샷 2025-08-04 19 27 53" src="https://github.com/user-attachments/assets/e70f3322-77f8-42f4-adc8-7846ec46b4e0" />

- 스토리북 빌드는 성공하지만 Chromatic 배포에서 오류 

## 🥳 To-Be

<!-- 변경 사항 -->

✔️ 변경사항 
  - rollupTypes를 false에서 true로 변경
  - 분산된 타입 파일 생성으로 인한 의존성 추적 문제 해결
  - Vite 기반 Storybook에서 TurboSnap이 제대로 작동하도록 수정

✔️ rollupTypes: false일 때 (Chip의 원래 설정)
  - 개별 타입 파일들이 생성됨 (Chip.d.ts, style.css.d.ts, types.d.ts)
  - 파일 구조가 분산되어 있음
  - Chromatic의 TurboSnap이 의존성을 추적하기 어려움 (Chromatic v11의 경우)

따라서 다른 컴포넌트 처럼 rollupTypes을 true로 수정해서 해결해 보려고했습니다 🌀


## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)

## 👾 Additional Description (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 타입 선언 파일이 빌드 시 하나로 번들링되도록 설정이 변경되었습니다. (사용자 기능에는 직접적인 영향 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->