### PR TITLE
[NUGUDI-47] 공용 Input OTP 구현 

### DIFF
--- a/apps/web/app/components/input-otp-container.tsx
+++ b/apps/web/app/components/input-otp-container.tsx
@@ -1,0 +1,61 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@nugudi/react-components-button";
+import { InputOTP } from "@nugudi/react-components-input-otp";
+import { Controller, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const otpSchema = z.object({
+  otp: z.string().min(6, "6자리 인증번호를 입력해주세요"),
+});
+
+type OTPFormData = z.infer<typeof otpSchema>;
+
+export default function InputOTPContainer() {
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid },
+  } = useForm<OTPFormData>({
+    resolver: zodResolver(otpSchema),
+    mode: "onSubmit",
+    defaultValues: {
+      otp: "",
+    },
+  });
+
+  const onSubmit = (data: OTPFormData) => {
+    console.log("OTP 제출:", data.otp);
+    alert(`OTP 제출: ${data.otp}`);
+  };
+
+  return (
+    <div style={{ marginTop: "4rem" }}>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+          maxWidth: "400px",
+        }}
+      >
+        <Controller
+          name="otp"
+          control={control}
+          render={({ field, fieldState }) => (
+            <InputOTP
+              {...field}
+              length={6}
+              isError={!!fieldState.error}
+              errorMessage={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <Button type="submit" color="main" disabled={!isValid}>
+          인증번호 확인
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -35,7 +35,15 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" suppressHydrationWarning={true}>
-      <body className={Pretendard.variable} suppressHydrationWarning={true}>
+      <body
+        className={Pretendard.variable}
+        suppressHydrationWarning={true}
+        style={{
+          width: "100%",
+          maxWidth: "600px",
+          margin: "0 auto",
+        }}
+      >
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/apps/web/app/page.css.ts
+++ b/apps/web/app/page.css.ts
@@ -4,7 +4,8 @@ import { style } from "@vanilla-extract/css";
 export const container = style({
   display: "flex",
   flexDirection: "column",
-  justifyContent: "center",
+  padding: "1rem",
+  height: "100%",
 });
 
 export const section = style({

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,18 +10,19 @@ import { Tabs } from "@nugudi/react-components-tab";
 import { ButtonContainer } from "./components/button-container";
 import ChipContainer from "./components/chip-container";
 import InputContainer from "./components/input-container";
+import InputOTPContainer from "./components/input-otp-container";
 import * as styles from "./page.css";
 
 export default function Home() {
   return (
-    <div>
-      <Tabs defaultValue="tab1">
-        <Tabs.List>
-          <Tabs.Item value="tab1">식당 정보</Tabs.Item>
-          <Tabs.Item value="tab2">리뷰</Tabs.Item>
-        </Tabs.List>
+    <Tabs defaultValue="tab1">
+      <Tabs.List>
+        <Tabs.Item value="tab1">식당 정보</Tabs.Item>
+        <Tabs.Item value="tab2">리뷰</Tabs.Item>
+      </Tabs.List>
 
-        <Tabs.Panel value="tab1">
+      <Tabs.Panel value="tab1">
+        <div className={styles.container}>
           <h3>첫 번째 탭 내용</h3>
 
           <Heading as="h1" fontSize="h1" color="blackAlpha">
@@ -38,17 +39,17 @@ export default function Home() {
             </Heading>
           </Box>
           <Divider color="main" size={5} />
-
           <ButtonContainer />
-        </Tabs.Panel>
+        </div>
+      </Tabs.Panel>
 
-        <Tabs.Panel value="tab2">
-          <div className={styles.container}>
-            <ChipContainer />
-            <InputContainer />
-          </div>
-        </Tabs.Panel>
-      </Tabs>
-    </div>
+      <Tabs.Panel value="tab2" className={styles.container}>
+        <div className={styles.container}>
+          <ChipContainer />
+          <InputContainer />
+          <InputOTPContainer />
+        </div>
+      </Tabs.Panel>
+    </Tabs>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@nugudi/react-components-button": "workspace:*",
     "@nugudi/react-components-chip": "workspace:*",
     "@nugudi/react-components-input": "workspace:*",
+    "@nugudi/react-components-input-otp": "workspace:*",
     "@nugudi/react-components-layout": "workspace:*",
     "@nugudi/react-components-tab": "workspace:*",
     "@nugudi/react-hooks-button": "workspace:*",

--- a/apps/web/src/shared/styles/fds.module.css
+++ b/apps/web/src/shared/styles/fds.module.css
@@ -4,3 +4,4 @@
 @import '@nugudi/react-components-input/style.css';
 @import '@nugudi/react-components-tab/style.css';
 @import '@nugudi/react-components-chip/style.css';
+@import '@nugudi/react-components-input-otp/style.css';

--- a/packages/react/components/input-otp/README.md
+++ b/packages/react/components/input-otp/README.md
@@ -1,0 +1,136 @@
+# @nugudi/react-components-input-otp
+
+React InputOTP 컴포넌트 라이브러리입니다. OTP(일회용 비밀번호) 입력을 위한 간단하고 유연한 인터페이스를 제공합니다.
+
+## 설치
+
+```bash
+npm install @nugudi/react-components-input-otp
+```
+
+## 기본 사용법
+
+### Uncontrolled 방식 (간단)
+
+```tsx
+import { InputOTP } from "@nugudi/react-components-input-otp";
+
+const App = () => {
+  return (
+    <InputOTP
+      defaultValue="123"
+      onChange={(value) => console.log("OTP:", value)}
+    />
+  );
+};
+```
+
+### Controlled 방식
+
+```tsx
+import { InputOTP } from "@nugudi/react-components-input-otp";
+import { useState } from "react";
+
+const App = () => {
+  const [otp, setOtp] = useState("");
+
+  return <InputOTP value={otp} onChange={setOtp} />;
+};
+```
+
+### react-hook-form과 함께 사용
+
+```tsx
+import { InputOTP } from "@nugudi/react-components-input-otp";
+import { useForm, Controller } from "react-hook-form";
+
+const App = () => {
+  const { control, handleSubmit } = useForm();
+
+  const onSubmit = (data) => {
+    console.log("OTP:", data.otp);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Controller
+        name="otp"
+        control={control}
+        rules={{ required: "OTP를 입력해주세요" }}
+        render={({ field, fieldState }) => (
+          <InputOTP
+            {...field}
+            isError={!!fieldState.error}
+            errorMessage={fieldState.error?.message}
+          />
+        )}
+      />
+      <button type="submit">제출</button>
+    </form>
+  );
+};
+```
+
+### 커스텀 길이
+
+```tsx
+<InputOTP length={4} />
+```
+
+### 에러 상태
+
+```tsx
+<InputOTP isError={true} errorMessage="잘못된 인증번호입니다." />
+```
+
+### 알파벳 입력
+
+```tsx
+<InputOTP inputMode="text" pattern="[a-zA-Z]*" />
+```
+
+### 영숫자 입력
+
+```tsx
+<InputOTP inputMode="text" pattern="[a-zA-Z0-9]*" />
+```
+
+## 패턴 예시
+
+### 숫자만 허용 (기본)
+
+```tsx
+pattern = "[0-9]*";
+```
+
+### 대소문자 구분 없는 알파벳
+
+```tsx
+pattern = "[a-zA-Z]*";
+```
+
+### 영숫자 조합
+
+```tsx
+pattern = "[a-zA-Z0-9]*";
+```
+
+## 기능
+
+- ✅ 자동 포커스 이동
+- ✅ 백스페이스로 이전 필드 이동
+- ✅ 화살표 키로 필드 간 이동
+- ✅ 붙여넣기 지원
+- ✅ 입력 패턴 검증
+- ✅ 에러 상태 표시
+- ✅ 모바일 키보드 최적화
+- ✅ react-hook-form 호환성
+- ✅ Controlled/Uncontrolled 모드 지원
+
+## 접근성
+
+이 컴포넌트는 웹 접근성을 고려하여 설계되었습니다:
+
+- 키보드 네비게이션 지원 (화살표 키, 백스페이스)
+- 적절한 `inputMode`와 `pattern` 속성으로 모바일 경험 최적화
+- 에러 상태에서 명확한 시각적 피드백 제공

--- a/packages/react/components/input-otp/package.json
+++ b/packages/react/components/input-otp/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@nugudi/react-components-input-otp",
+  "version": "0.0.1",
+  "sideEffects": [
+    "**/*.css",
+    "./dist/index.css"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./style.css": "./dist/index.css"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "check-types": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
+  },
+  "dependencies": {
+    "@nugudi/react-hooks-button": "workspace:*",
+    "@nugudi/themes": "workspace:*",
+    "@vanilla-extract/css": "^1.17.4",
+    "@vanilla-extract/dynamic": "^2.1.5",
+    "@vanilla-extract/recipes": "^0.5.7",
+    "@vanilla-extract/sprinkles": "^1.6.5",
+    "clsx": "^2.1.1"
+  },
+  "devDependencies": {
+    "@tsconfig/vite-react": "^3.4.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vanilla-extract/vite-plugin": "^5.1.1",
+    "@vitejs/plugin-react": "^4.7.0",
+    "typescript": "^5.8.3",
+    "vite": "^6.0.7",
+    "vite-plugin-dts": "^4.5.2",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.3"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/react/components/input-otp/package.json
+++ b/packages/react/components/input-otp/package.json
@@ -35,14 +35,14 @@
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@tsconfig/vite-react": "^3.4.0",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
+    "@tsconfig/vite-react": "^6.3.6",
+    "@types/react": "^19.1.9",
+    "@types/react-dom": "^19.1.7",
     "@vanilla-extract/vite-plugin": "^5.1.1",
     "@vitejs/plugin-react": "^4.7.0",
     "typescript": "^5.8.3",
-    "vite": "^6.0.7",
-    "vite-plugin-dts": "^4.5.2",
+    "vite": "^6.3.5",
+    "vite-plugin-dts": "^4.5.4",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.3"
   },

--- a/packages/react/components/input-otp/package.json
+++ b/packages/react/components/input-otp/package.json
@@ -27,7 +27,6 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "@nugudi/react-hooks-button": "workspace:*",
     "@nugudi/themes": "workspace:*",
     "@vanilla-extract/css": "^1.17.4",
     "@vanilla-extract/dynamic": "^2.1.5",

--- a/packages/react/components/input-otp/src/InputOTP.tsx
+++ b/packages/react/components/input-otp/src/InputOTP.tsx
@@ -1,0 +1,108 @@
+import { clsx } from "clsx";
+import * as React from "react";
+import {
+  containerStyle,
+  errorMessageStyle,
+  inputContainerStyle,
+  otpInputStyle,
+} from "./style.css";
+import type { InputOTPProps } from "./types";
+import { useInputOTP } from "./useInputOTP";
+
+const InputOTP = (props: InputOTPProps, ref: React.Ref<HTMLDivElement>) => {
+  const {
+    length = 6,
+    value,
+    defaultValue,
+    onChange,
+    onBlur,
+    onFocus,
+    disabled = false,
+    className,
+    inputClassName,
+    isError = false,
+    invalid,
+    errorMessage,
+    inputMode = "numeric",
+    pattern = "[0-9]*",
+    id,
+    name,
+    "aria-describedby": ariaDescribedBy,
+    ...rest
+  } = props;
+
+  const {
+    value: currentValue,
+    // biome-ignore lint/correctness/noUnusedVariables: <ef={(el) => inputRefs.current[index] = el>
+    inputRefs,
+    handleInputChange,
+    handleKeyDown,
+    handleFocus,
+    handlePaste,
+    containerProps,
+  } = useInputOTP({
+    length,
+    pattern,
+    invalid: invalid || isError,
+    errorMessage,
+    value: value || defaultValue,
+    onChange,
+    onBlur,
+    onFocus,
+    disabled,
+    id,
+    "aria-describedby": ariaDescribedBy,
+  });
+
+  return (
+    <div
+      ref={ref}
+      className={clsx(containerStyle, className)}
+      {...containerProps}
+      {...rest}
+    >
+      <div className={inputContainerStyle}>
+        {Array.from({ length }, (_, index) => (
+          <input
+            // biome-ignore lint/suspicious/noArrayIndexKey: <onChange={(e) => handleInputChange(index, e.target.value)}>
+            key={index}
+            ref={(el) => {
+              inputRefs.current[index] = el;
+            }}
+            type="text"
+            inputMode={inputMode}
+            pattern={pattern}
+            maxLength={1}
+            name={name ? `${name}-${index}` : undefined}
+            value={currentValue[index] || ""}
+            onChange={(e) => handleInputChange(index, e.target.value)}
+            onKeyDown={(e) => handleKeyDown(index, e)}
+            onFocus={() => handleFocus(index)}
+            onPaste={index === 0 ? handlePaste : undefined}
+            disabled={disabled}
+            className={clsx(
+              otpInputStyle({
+                isError: isError || invalid,
+                isFilled: !!currentValue[index],
+              }),
+              inputClassName,
+            )}
+          />
+        ))}
+      </div>
+      {(isError || invalid) && errorMessage && (
+        <div
+          id={containerProps["aria-describedby"]
+            ?.split(" ")
+            .find((id) => id.includes("error"))}
+          className={errorMessageStyle}
+        >
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const _InputOTP = React.forwardRef(InputOTP);
+export { _InputOTP as InputOTP };

--- a/packages/react/components/input-otp/src/InputOTP.tsx
+++ b/packages/react/components/input-otp/src/InputOTP.tsx
@@ -21,7 +21,6 @@ const InputOTP = (props: InputOTPProps, ref: React.Ref<HTMLDivElement>) => {
     className,
     inputClassName,
     isError = false,
-    invalid,
     errorMessage,
     inputMode = "numeric",
     pattern = "[0-9]*",
@@ -43,7 +42,7 @@ const InputOTP = (props: InputOTPProps, ref: React.Ref<HTMLDivElement>) => {
   } = useInputOTP({
     length,
     pattern,
-    invalid: invalid || isError,
+    isError,
     errorMessage,
     value: value || defaultValue,
     onChange,
@@ -64,7 +63,7 @@ const InputOTP = (props: InputOTPProps, ref: React.Ref<HTMLDivElement>) => {
       <div className={inputContainerStyle}>
         {Array.from({ length }, (_, index) => (
           <input
-            // biome-ignore lint/suspicious/noArrayIndexKey: <onChange={(e) => handleInputChange(index, e.target.value)}>
+            // biome-ignore lint/suspicious/noArrayIndexKey: <Array length is fixed and order doesn't change>
             key={index}
             ref={(el) => {
               inputRefs.current[index] = el;
@@ -82,7 +81,7 @@ const InputOTP = (props: InputOTPProps, ref: React.Ref<HTMLDivElement>) => {
             disabled={disabled}
             className={clsx(
               otpInputStyle({
-                isError: isError || invalid,
+                isError,
                 isFilled: !!currentValue[index],
               }),
               inputClassName,
@@ -90,7 +89,7 @@ const InputOTP = (props: InputOTPProps, ref: React.Ref<HTMLDivElement>) => {
           />
         ))}
       </div>
-      {(isError || invalid) && errorMessage && (
+      {isError && errorMessage && (
         <div
           id={containerProps["aria-describedby"]
             ?.split(" ")

--- a/packages/react/components/input-otp/src/index.ts
+++ b/packages/react/components/input-otp/src/index.ts
@@ -1,0 +1,3 @@
+export { InputOTP } from "./InputOTP";
+export type { InputOTPProps } from "./types";
+export { useInputOTP } from "./useInputOTP";

--- a/packages/react/components/input-otp/src/style.css.ts
+++ b/packages/react/components/input-otp/src/style.css.ts
@@ -1,0 +1,65 @@
+import { classes, vars } from "@nugudi/themes";
+import { style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
+
+export const containerStyle = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+  width: "100%",
+});
+
+export const inputContainerStyle = style({
+  display: "flex",
+  gap: "8px",
+});
+
+export const otpInputStyle = recipe({
+  base: {
+    width: "45px",
+    height: "55px",
+    textAlign: "center",
+    borderRadius: vars.box.radii.xl,
+    backgroundColor: vars.colors.$scale.zinc[50],
+    transition: "all 0.2s ease",
+    outline: "none",
+    border: "none",
+    caretColor: vars.colors.$scale.zinc[300],
+    ...classes.typography.title.t1,
+    fontWeight: vars.typography.fontWeight[600],
+    ":disabled": {
+      opacity: 0.5,
+      cursor: "not-allowed",
+    },
+  },
+
+  variants: {
+    isError: {
+      true: {
+        backgroundColor: `${vars.colors.$static.light.color.red}1A`,
+        color: vars.colors.$static.light.color.red,
+      },
+    },
+    isFilled: {
+      true: {
+        backgroundColor: vars.colors.$scale.zinc[100],
+      },
+    },
+  },
+  compoundVariants: [
+    {
+      variants: {
+        isError: true,
+        isFilled: true,
+      },
+      style: {
+        backgroundColor: `${vars.colors.$static.light.color.red}1A`,
+      },
+    },
+  ],
+});
+
+export const errorMessageStyle = style({
+  ...classes.typography.emphasis.e2,
+  color: vars.colors.$static.light.color.red,
+});

--- a/packages/react/components/input-otp/src/types.ts
+++ b/packages/react/components/input-otp/src/types.ts
@@ -1,0 +1,57 @@
+import type {
+  ClipboardEvent,
+  FocusEvent,
+  KeyboardEvent,
+  MutableRefObject,
+} from "react";
+
+export interface UseInputOTPProps {
+  length?: number;
+  pattern?: string;
+  invalid?: boolean;
+  errorMessage?: string;
+  value?: string;
+  onChange?: (value: string) => void;
+  onBlur?: (e: FocusEvent<HTMLDivElement>) => void;
+  onFocus?: (e: FocusEvent<HTMLDivElement>) => void;
+  disabled?: boolean;
+  id?: string;
+  name?: string;
+  "aria-describedby"?: string;
+}
+
+export interface UseInputOTPReturn {
+  value: string;
+  inputRefs: MutableRefObject<(HTMLInputElement | null)[]>;
+  handleInputChange: (index: number, inputValue: string) => void;
+  handleKeyDown: (index: number, e: KeyboardEvent<HTMLInputElement>) => void;
+  handleFocus: (index: number) => void;
+  handlePaste: (e: ClipboardEvent<HTMLInputElement>) => void;
+  containerProps: {
+    id?: string;
+    "aria-invalid"?: boolean;
+    "aria-describedby"?: string;
+    onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
+    onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
+  };
+}
+
+export interface InputOTPProps {
+  length?: number;
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  onBlur?: (e: FocusEvent<HTMLDivElement>) => void;
+  onFocus?: (e: FocusEvent<HTMLDivElement>) => void;
+  disabled?: boolean;
+  className?: string;
+  inputClassName?: string;
+  isError?: boolean;
+  invalid?: boolean;
+  errorMessage?: string;
+  inputMode?: "text" | "numeric";
+  pattern?: string;
+  id?: string;
+  name?: string;
+  "aria-describedby"?: string;
+}

--- a/packages/react/components/input-otp/src/types.ts
+++ b/packages/react/components/input-otp/src/types.ts
@@ -8,7 +8,7 @@ import type {
 export interface UseInputOTPProps {
   length?: number;
   pattern?: string;
-  invalid?: boolean;
+  isError?: boolean;
   errorMessage?: string;
   value?: string;
   onChange?: (value: string) => void;
@@ -31,8 +31,8 @@ export interface UseInputOTPReturn {
     id?: string;
     "aria-invalid"?: boolean;
     "aria-describedby"?: string;
-    onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
-    onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
+    onBlur?: (e: FocusEvent<HTMLDivElement>) => void;
+    onFocus?: (e: FocusEvent<HTMLDivElement>) => void;
   };
 }
 
@@ -47,7 +47,6 @@ export interface InputOTPProps {
   className?: string;
   inputClassName?: string;
   isError?: boolean;
-  invalid?: boolean;
   errorMessage?: string;
   inputMode?: "text" | "numeric";
   pattern?: string;

--- a/packages/react/components/input-otp/src/useInputOTP.ts
+++ b/packages/react/components/input-otp/src/useInputOTP.ts
@@ -1,0 +1,188 @@
+import type { ClipboardEvent, KeyboardEvent } from "react";
+import { useCallback, useRef, useState } from "react";
+import type { UseInputOTPProps, UseInputOTPReturn } from "./types";
+
+export const useInputOTP = (props: UseInputOTPProps): UseInputOTPReturn => {
+  const {
+    length = 6,
+    pattern = "[0-9]*",
+    invalid,
+    errorMessage,
+    value: controlledValue,
+    onChange,
+    onBlur,
+    onFocus,
+    disabled,
+    id,
+    "aria-describedby": ariaDescribedBy,
+  } = props;
+
+  const [internalValue, setInternalValue] = useState("");
+
+  // Controlled vs Uncontrolled 처리
+  const isControlled = controlledValue !== undefined;
+  const value = isControlled ? controlledValue : internalValue;
+  const setValue = isControlled
+    ? (newValue: string) => {
+        onChange?.(newValue);
+      }
+    : (newValue: string) => {
+        setInternalValue(newValue);
+        onChange?.(newValue);
+      };
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  /**
+   * 입력값이 지정된 패턴에 맞는지 검증
+   */
+  const validateInput = useCallback(
+    (input: string) => {
+      const regex = new RegExp(`^${pattern}$`);
+      return regex.test(input);
+    },
+    [pattern],
+  );
+
+  /**
+   * 입력값 변경 처리
+   * - 단일 문자 입력 및 다중 문자 붙여넣기 지원
+   * - 자동 포커스 이동
+   */
+  const handleInputChange = useCallback(
+    (index: number, inputValue: string) => {
+      if (disabled) return;
+
+      // 빈 문자열은 항상 허용 (삭제 허용)
+      if (inputValue !== "" && !validateInput(inputValue)) {
+        return;
+      }
+
+      if (inputValue.length > 1) {
+        const pastedValue = inputValue.slice(0, length - index);
+        const newValue = value.split("");
+
+        for (let i = 0; i < pastedValue.length; i++) {
+          if (index + i < length) {
+            // 각 문자가 패턴에 맞는지 검증
+            if (validateInput(pastedValue[i])) {
+              newValue[index + i] = pastedValue[i];
+            }
+          }
+        }
+
+        const updatedValue = newValue.join("");
+        setValue(updatedValue);
+        onChange?.(updatedValue);
+
+        const nextIndex = Math.min(index + pastedValue.length, length - 1);
+        inputRefs.current[nextIndex]?.focus();
+
+        return;
+      }
+
+      const newValue = value.split("");
+      newValue[index] = inputValue;
+      const updatedValue = newValue.join("");
+
+      setValue(updatedValue);
+      onChange?.(updatedValue);
+
+      if (inputValue && index < length - 1) {
+        inputRefs.current[index + 1]?.focus();
+      }
+    },
+    [length, value, onChange, disabled, validateInput, setValue],
+  );
+
+  /**
+   * 키보드 이벤트 처리
+   * - Backspace: 현재 입력 삭제 및 이전 칸로 이동
+   * - Arrow Keys: 좌우 네비게이션
+   */
+  const handleKeyDown = useCallback(
+    (index: number, e: KeyboardEvent<HTMLInputElement>) => {
+      if (disabled) return;
+
+      if (e.key === "Backspace") {
+        e.preventDefault();
+
+        if (value[index]) {
+          const newValue = value.split("");
+          newValue[index] = "";
+          const updatedValue = newValue.join("");
+          setValue(updatedValue);
+          onChange?.(updatedValue);
+        } else if (index > 0) {
+          inputRefs.current[index - 1]?.focus();
+          const newValue = value.split("");
+          newValue[index - 1] = "";
+          const updatedValue = newValue.join("");
+          setValue(updatedValue);
+          onChange?.(updatedValue);
+        }
+      } else if (e.key === "ArrowLeft" && index > 0) {
+        e.preventDefault();
+        inputRefs.current[index - 1]?.focus();
+      } else if (e.key === "ArrowRight" && index < length - 1) {
+        e.preventDefault();
+        inputRefs.current[index + 1]?.focus();
+      }
+    },
+    [value, onChange, length, disabled, setValue],
+  );
+
+  /**
+   * 입력 칸 포커스 처리
+   * - 포커스 시 전체 텍스트 선택
+   */
+  const handleFocus = useCallback((index: number) => {
+    inputRefs.current[index]?.select();
+  }, []);
+
+  /**
+   * 붙여넣기 이벤트 처리
+   * - 클립보드 데이터에서 패턴에 맞는 문자만 필터링
+   * - 자동 포커스 이동
+   */
+  const handlePaste = useCallback(
+    (e: ClipboardEvent<HTMLInputElement>) => {
+      if (disabled) return;
+
+      e.preventDefault();
+      const pastedData = e.clipboardData.getData("text/plain").slice(0, length);
+
+      // 붙여넣기 데이터에서 패턴에 맞는 문자만 필터링
+      const filteredData = pastedData
+        .split("")
+        .filter((char) => validateInput(char))
+        .join("");
+
+      setValue(filteredData);
+      onChange?.(filteredData);
+
+      inputRefs.current[Math.min(filteredData.length, length - 1)]?.focus();
+    },
+    [length, onChange, disabled, validateInput, setValue],
+  );
+
+  const errorId = errorMessage && id ? `${id}-error` : undefined;
+
+  const containerProps = {
+    id,
+    "aria-invalid": invalid,
+    "aria-describedby":
+      [ariaDescribedBy, errorId].filter(Boolean).join(" ") || undefined,
+    onFocus,
+    onBlur,
+  };
+
+  return {
+    value,
+    inputRefs,
+    handleInputChange,
+    handleKeyDown,
+    handleFocus,
+    handlePaste,
+    containerProps,
+  };
+};

--- a/packages/react/components/input-otp/src/useInputOTP.ts
+++ b/packages/react/components/input-otp/src/useInputOTP.ts
@@ -6,7 +6,7 @@ export const useInputOTP = (props: UseInputOTPProps): UseInputOTPReturn => {
   const {
     length = 6,
     pattern = "[0-9]*",
-    invalid,
+    isError,
     errorMessage,
     value: controlledValue,
     onChange,
@@ -72,7 +72,6 @@ export const useInputOTP = (props: UseInputOTPProps): UseInputOTPReturn => {
 
         const updatedValue = newValue.join("");
         setValue(updatedValue);
-        onChange?.(updatedValue);
 
         const nextIndex = Math.min(index + pastedValue.length, length - 1);
         inputRefs.current[nextIndex]?.focus();
@@ -85,13 +84,12 @@ export const useInputOTP = (props: UseInputOTPProps): UseInputOTPReturn => {
       const updatedValue = newValue.join("");
 
       setValue(updatedValue);
-      onChange?.(updatedValue);
 
       if (inputValue && index < length - 1) {
         inputRefs.current[index + 1]?.focus();
       }
     },
-    [length, value, onChange, disabled, validateInput, setValue],
+    [length, value, disabled, validateInput, setValue],
   );
 
   /**
@@ -111,14 +109,12 @@ export const useInputOTP = (props: UseInputOTPProps): UseInputOTPReturn => {
           newValue[index] = "";
           const updatedValue = newValue.join("");
           setValue(updatedValue);
-          onChange?.(updatedValue);
         } else if (index > 0) {
           inputRefs.current[index - 1]?.focus();
           const newValue = value.split("");
           newValue[index - 1] = "";
           const updatedValue = newValue.join("");
           setValue(updatedValue);
-          onChange?.(updatedValue);
         }
       } else if (e.key === "ArrowLeft" && index > 0) {
         e.preventDefault();
@@ -128,7 +124,7 @@ export const useInputOTP = (props: UseInputOTPProps): UseInputOTPReturn => {
         inputRefs.current[index + 1]?.focus();
       }
     },
-    [value, onChange, length, disabled, setValue],
+    [value, length, disabled, setValue],
   );
 
   /**
@@ -158,18 +154,17 @@ export const useInputOTP = (props: UseInputOTPProps): UseInputOTPReturn => {
         .join("");
 
       setValue(filteredData);
-      onChange?.(filteredData);
 
       inputRefs.current[Math.min(filteredData.length, length - 1)]?.focus();
     },
-    [length, onChange, disabled, validateInput, setValue],
+    [length, disabled, validateInput, setValue],
   );
 
   const errorId = errorMessage && id ? `${id}-error` : undefined;
 
   const containerProps = {
     id,
-    "aria-invalid": invalid,
+    "aria-invalid": isError,
     "aria-describedby":
       [ariaDescribedBy, errorId].filter(Boolean).join(" ") || undefined,
     onFocus,

--- a/packages/react/components/input-otp/tsconfig.json
+++ b/packages/react/components/input-otp/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@tsconfig/vite-react/tsconfig.json",
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "./global.d.ts",
+    "vite.config.mts",
+    "vitest.config.mts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/packages/react/components/input-otp/vite.config.mts
+++ b/packages/react/components/input-otp/vite.config.mts
@@ -1,0 +1,56 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+const _filename = fileURLToPath(import.meta.url);
+const _dirname = dirname(_filename);
+
+export default defineConfig({
+  plugins: [
+    react(),
+    vanillaExtractPlugin(),
+    dts({
+      include: ["src"],
+      exclude: ["src/**/*.stories.tsx", "src/**/*.test.tsx"],
+      outDir: "dist",
+      entryRoot: "src",
+      insertTypesEntry: true,
+      rollupTypes: false,
+      tsconfigPath: "./tsconfig.json",
+    }),
+    tsconfigPaths(),
+  ],
+  build: {
+    lib: {
+      entry: resolve(_dirname, "src/index.ts"),
+      fileName: "index",
+      formats: ["es"],
+    },
+    rollupOptions: {
+      external: [
+        "react",
+        "react-dom",
+        "react/jsx-runtime",
+        "@vanilla-extract/css",
+      ],
+      output: {
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name?.endsWith(".css")) return "index.css";
+          return assetInfo.name || "assets/[name].[ext]";
+        },
+      },
+    },
+    sourcemap: true,
+    minify: false,
+    outDir: "dist",
+  },
+  resolve: {
+    alias: {
+      "@": resolve(_dirname, "./src"),
+    },
+  },
+});

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -59,6 +59,7 @@ const config: StorybookConfig = {
       "@nugudi/react-components-input",
       "@nugudi/react-components-tab",
       "@nugudi/react-components-chip",
+      "@nugudi/react-components-input-otp",
       "@nugudi/react-hooks-button",
       "@nugudi/themes",
     ];

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,6 +31,7 @@
     "@nugudi/react-components-button": "workspace:*",
     "@nugudi/react-components-chip": "workspace:*",
     "@nugudi/react-components-input": "workspace:*",
+    "@nugudi/react-components-input-otp": "workspace:*",
     "@nugudi/react-components-layout": "workspace:*",
     "@nugudi/react-components-tab": "workspace:*",
     "@nugudi/react-hooks-button": "workspace:*",

--- a/packages/ui/src/ReactComponents/InputOtp.stories.tsx
+++ b/packages/ui/src/ReactComponents/InputOtp.stories.tsx
@@ -1,0 +1,155 @@
+import "@nugudi/react-components-input-otp/style.css";
+import { InputOTP } from "@nugudi/react-components-input-otp";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof InputOTP> = {
+  title: "Components/InputOTP",
+  component: InputOTP,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "InputOTP는 일회용 비밀번호나 인증번호 입력을 위한 컴포넌트입니다.",
+      },
+    },
+    a11y: {
+      element: "#storybook-root",
+      config: {
+        rules: [
+          {
+            id: "color-contrast",
+            enabled: true,
+          },
+          {
+            id: "label",
+            enabled: true,
+          },
+        ],
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    length: {
+      control: { type: "range", min: 4, max: 8, step: 1 },
+      description: "OTP 입력 필드의 개수를 설정합니다",
+      table: {
+        type: { summary: "number" },
+        defaultValue: { summary: "6" },
+        category: "Basic",
+      },
+    },
+    disabled: {
+      control: "boolean",
+      description: "입력 필드를 비활성화합니다",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "State",
+      },
+    },
+    isError: {
+      control: "boolean",
+      description: "에러 상태를 표시합니다 (빨간색 테두리)",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "State",
+      },
+    },
+    errorMessage: {
+      control: "text",
+      description: "에러 상태일 때 표시할 메시지",
+      table: {
+        type: { summary: "string" },
+        category: "State",
+      },
+    },
+    inputMode: {
+      control: "select",
+      options: ["text", "numeric"],
+      description: "입력 모드를 설정합니다",
+      table: {
+        type: { summary: "text | numeric" },
+        defaultValue: { summary: "numeric" },
+        category: "Input",
+      },
+    },
+    pattern: {
+      control: "text",
+      description: "입력 가능한 문자를 정규식으로 제한합니다",
+      table: {
+        type: { summary: "string (RegExp)" },
+        defaultValue: { summary: "[0-9]*" },
+        category: "Input",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => {
+    return (
+      <InputOTP
+        {...args}
+        onChange={(value) => console.log("OTP changed:", value)}
+      />
+    );
+  },
+};
+
+export const WithError: Story = {
+  render: (args) => {
+    return (
+      <InputOTP
+        {...args}
+        isError={true}
+        errorMessage="잘못된 인증번호입니다."
+        onChange={(value) => console.log("OTP changed:", value)}
+      />
+    );
+  },
+};
+
+export const DifferentLengths: Story = {
+  render: () => {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+        <div>
+          <h3 style={{ marginBottom: "8px" }}>4자리</h3>
+          <InputOTP length={4} />
+        </div>
+        <div>
+          <h3 style={{ marginBottom: "8px" }}>6자리 (Default)</h3>
+          <InputOTP length={6} />
+        </div>
+        <div>
+          <h3 style={{ marginBottom: "8px" }}>8자리</h3>
+          <InputOTP length={8} />
+        </div>
+      </div>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: () => {
+    return <InputOTP disabled defaultValue="123456" />;
+  },
+};
+
+export const AlphabeticPattern: Story = {
+  render: () => {
+    return (
+      <div>
+        <p style={{ marginBottom: "8px" }}>알파벳만 입력 가능</p>
+        <InputOTP inputMode="text" pattern="[a-zA-Z]*" />
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/ReactComponents/InputOtp.stories.tsx
+++ b/packages/ui/src/ReactComponents/InputOtp.stories.tsx
@@ -13,21 +13,6 @@ const meta: Meta<typeof InputOTP> = {
           "InputOTP는 일회용 비밀번호나 인증번호 입력을 위한 컴포넌트입니다.",
       },
     },
-    a11y: {
-      element: "#storybook-root",
-      config: {
-        rules: [
-          {
-            id: "color-contrast",
-            enabled: true,
-          },
-          {
-            id: "label",
-            enabled: true,
-          },
-        ],
-      },
-    },
   },
   tags: ["autodocs"],
   argTypes: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,13 +115,13 @@ importers:
         version: link:../../packages/themes
       '@sentry/nextjs':
         specifier: ^9.31.0
-        version: 9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.99.6)
+        version: 9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.99.6)
       '@tanstack/react-query':
         specifier: ^5.81.2
         version: 5.83.1(react@19.1.1)
       next:
         specifier: 15.3.3
-        version: 15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       pretendard:
         specifier: ^1.3.9
         version: 1.3.9
@@ -149,7 +149,7 @@ importers:
         version: 1.17.4
       '@vanilla-extract/next-plugin':
         specifier: ^2.4.14
-        version: 2.4.14(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.99.6)
+        version: 2.4.14(next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.99.6)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
         version: 4.7.0(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
@@ -410,9 +410,6 @@ importers:
 
   packages/react/components/input-otp:
     dependencies:
-      '@nugudi/react-hooks-button':
-        specifier: workspace:*
-        version: link:../../hooks/button
       '@nugudi/themes':
         specifier: workspace:*
         version: link:../../../themes
@@ -7583,7 +7580,7 @@ snapshots:
 
   '@sentry/core@9.44.0': {}
 
-  '@sentry/nextjs@9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.99.6)':
+  '@sentry/nextjs@9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.99.6)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.34.0
@@ -7596,7 +7593,7 @@ snapshots:
       '@sentry/vercel-edge': 9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       '@sentry/webpack-plugin': 3.5.0(webpack@5.99.6)
       chalk: 3.0.0
-      next: 15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       resolve: 1.22.8
       rollup: 4.35.0
       stacktrace-parser: 0.1.11
@@ -8291,10 +8288,10 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@vanilla-extract/next-plugin@2.4.14(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.99.6)':
+  '@vanilla-extract/next-plugin@2.4.14(next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.99.6)':
     dependencies:
       '@vanilla-extract/webpack-plugin': 2.3.22(webpack@5.99.6)
-      next: 15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8404,6 +8401,26 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser@3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/utils': 3.2.4
+      magic-string: 0.30.17
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@24.1.0)(@vitest/browser@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      ws: 8.18.3
+    optionalDependencies:
+      playwright: 1.54.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/coverage-v8@3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -8450,6 +8467,16 @@ snapshots:
     optionalDependencies:
       msw: 2.10.4(@types/node@24.1.0)(typescript@5.8.3)
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+
+  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.10.4(@types/node@24.1.0)(typescript@5.8.3)
+      vite: 7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+    optional: true
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10433,7 +10460,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 15.3.3
       '@swc/counter': 0.1.3
@@ -10443,7 +10470,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      styled-jsx: 5.1.6(react@19.1.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.3.3
       '@next/swc-darwin-x64': 15.3.3
@@ -11348,10 +11375,12 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  styled-jsx@5.1.6(react@19.1.1):
+  styled-jsx@5.1.6(@babel/core@7.28.0)(react@19.1.1):
     dependencies:
       client-only: 0.0.1
       react: 19.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.0
 
   supports-color@5.5.0:
     dependencies:
@@ -11863,12 +11892,12 @@ snapshots:
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
-      chai: 5.2.1
+      chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.2
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
@@ -11880,7 +11909,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.1.0
-      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@nugudi/react-components-input':
         specifier: workspace:*
         version: link:../../packages/react/components/input
+      '@nugudi/react-components-input-otp':
+        specifier: workspace:*
+        version: link:../../packages/react/components/input-otp
       '@nugudi/react-components-layout':
         specifier: workspace:*
         version: link:../../packages/react/components/layout
@@ -112,13 +115,13 @@ importers:
         version: link:../../packages/themes
       '@sentry/nextjs':
         specifier: ^9.31.0
-        version: 9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.99.6)
+        version: 9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.99.6)
       '@tanstack/react-query':
         specifier: ^5.81.2
         version: 5.83.1(react@19.1.1)
       next:
         specifier: 15.3.3
-        version: 15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       pretendard:
         specifier: ^1.3.9
         version: 1.3.9
@@ -146,7 +149,7 @@ importers:
         version: 1.17.4
       '@vanilla-extract/next-plugin':
         specifier: ^2.4.14
-        version: 2.4.14(next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.99.6)
+        version: 2.4.14(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.99.6)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
         version: 4.7.0(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
@@ -405,6 +408,67 @@ importers:
         specifier: ^3.2.3
         version: 3.2.4(@types/node@24.1.0)(@vitest/browser@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
+  packages/react/components/input-otp:
+    dependencies:
+      '@nugudi/react-hooks-button':
+        specifier: workspace:*
+        version: link:../../hooks/button
+      '@nugudi/themes':
+        specifier: workspace:*
+        version: link:../../../themes
+      '@vanilla-extract/css':
+        specifier: ^1.17.4
+        version: 1.17.4
+      '@vanilla-extract/dynamic':
+        specifier: ^2.1.5
+        version: 2.1.5
+      '@vanilla-extract/recipes':
+        specifier: ^0.5.7
+        version: 0.5.7(@vanilla-extract/css@1.17.4)
+      '@vanilla-extract/sprinkles':
+        specifier: ^1.6.5
+        version: 1.6.5(@vanilla-extract/css@1.17.4)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      react:
+        specifier: ^19.0.0
+        version: 19.1.1
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.1(react@19.1.1)
+    devDependencies:
+      '@tsconfig/vite-react':
+        specifier: ^3.4.0
+        version: 3.4.0
+      '@types/react':
+        specifier: ^19
+        version: 19.1.9
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.1.7(@types/react@19.1.9)
+      '@vanilla-extract/vite-plugin':
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^6.0.7
+        version: 6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite-plugin-dts:
+        specifier: ^4.5.2
+        version: 4.5.4(@types/node@24.1.0)(rollup@4.46.2)(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      vitest:
+        specifier: ^3.2.3
+        version: 3.2.4(@types/node@24.1.0)(@vitest/browser@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+
   packages/react/components/layout:
     dependencies:
       '@nugudi/themes':
@@ -600,6 +664,9 @@ importers:
       '@nugudi/react-components-input':
         specifier: workspace:*
         version: link:../react/components/input
+      '@nugudi/react-components-input-otp':
+        specifier: workspace:*
+        version: link:../react/components/input-otp
       '@nugudi/react-components-layout':
         specifier: workspace:*
         version: link:../react/components/layout
@@ -5915,18 +5982,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.2:
-    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
@@ -7528,7 +7583,7 @@ snapshots:
 
   '@sentry/core@9.44.0': {}
 
-  '@sentry/nextjs@9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.99.6)':
+  '@sentry/nextjs@9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.99.6)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.34.0
@@ -7541,7 +7596,7 @@ snapshots:
       '@sentry/vercel-edge': 9.44.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       '@sentry/webpack-plugin': 3.5.0(webpack@5.99.6)
       chalk: 3.0.0
-      next: 15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       resolve: 1.22.8
       rollup: 4.35.0
       stacktrace-parser: 0.1.11
@@ -8236,10 +8291,10 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@vanilla-extract/next-plugin@2.4.14(next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.99.6)':
+  '@vanilla-extract/next-plugin@2.4.14(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.99.6)':
     dependencies:
       '@vanilla-extract/webpack-plugin': 2.3.22(webpack@5.99.6)
-      next: 15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8349,26 +8404,6 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)':
-    dependencies:
-      '@testing-library/dom': 10.4.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
-      '@vitest/utils': 3.2.4
-      magic-string: 0.30.17
-      sirv: 3.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.1.0)(@vitest/browser@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
-      ws: 8.18.3
-    optionalDependencies:
-      playwright: 1.54.1
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/coverage-v8@3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -8415,16 +8450,6 @@ snapshots:
     optionalDependencies:
       msw: 2.10.4(@types/node@24.1.0)(typescript@5.8.3)
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
-
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      msw: 2.10.4(@types/node@24.1.0)(typescript@5.8.3)
-      vite: 7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
-    optional: true
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10026,7 +10051,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.2
+      ws: 8.18.3
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -10408,7 +10433,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.3.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 15.3.3
       '@swc/counter': 0.1.3
@@ -10418,7 +10443,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.1)
+      styled-jsx: 5.1.6(react@19.1.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.3.3
       '@next/swc-darwin-x64': 15.3.3
@@ -11323,12 +11348,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  styled-jsx@5.1.6(@babel/core@7.28.0)(react@19.1.1):
+  styled-jsx@5.1.6(react@19.1.1):
     dependencies:
       client-only: 0.0.1
       react: 19.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.0
 
   supports-color@5.5.0:
     dependencies:
@@ -11840,12 +11863,12 @@ snapshots:
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
-      chai: 5.2.0
+      chai: 5.2.1
       debug: 4.4.1
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
@@ -11857,7 +11880,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.1.0
-      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
@@ -12027,8 +12050,6 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
-
-  ws@8.18.2: {}
 
   ws@8.18.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,13 +436,13 @@ importers:
         version: 19.1.1(react@19.1.1)
     devDependencies:
       '@tsconfig/vite-react':
-        specifier: ^3.4.0
-        version: 3.4.0
+        specifier: ^6.3.6
+        version: 6.3.6
       '@types/react':
-        specifier: ^19
+        specifier: ^19.1.9
         version: 19.1.9
       '@types/react-dom':
-        specifier: ^19
+        specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       '@vanilla-extract/vite-plugin':
         specifier: ^5.1.1
@@ -454,10 +454,10 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vite:
-        specifier: ^6.0.7
+        specifier: ^6.3.5
         version: 6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
       vite-plugin-dts:
-        specifier: ^4.5.2
+        specifier: ^4.5.4
         version: 4.5.4(@types/node@24.1.0)(rollup@4.46.2)(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4


### PR DESCRIPTION
## 🌀 Issue Number

<!-- #이슈번호 -->

- #51 

## 🥳 To-Be

<!-- 변경 사항 -->

- 공용 Input OTP 구현 
- apps/web 레이아웃 변경 (스타일 수정)


## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)

## 👾 Additional Description (Optional)
<img width="500" height="758" alt="스크린샷 2025-08-05 14 04 12" src="https://github.com/user-attachments/assets/2791cb8a-b2b3-4833-9713-3cad2927851d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * OTP(일회용 비밀번호) 입력을 위한 React 컴포넌트(InputOTP) 및 관련 훅(useInputOTP)이 추가되었습니다.
  * 웹 앱 내 OTP 입력 폼(InputOTPContainer)과 검증 기능이 도입되어 사용자 인증 경험이 향상되었습니다.
  * OTP 입력 길이, 입력 패턴(숫자, 영문, 영숫자 등), 에러 메시지 표시 등 다양한 옵션을 지원합니다.
  * Storybook에 OTP 입력 컴포넌트의 다양한 사용 예제와 설정이 추가되어 개발 및 테스트가 용이해졌습니다.

* **스타일**
  * OTP 입력 컴포넌트 및 컨테이너의 레이아웃과 상태별 스타일(오류, 입력 완료 등)이 새롭게 적용되었습니다.
  * 웹 앱 전체 레이아웃에 최대 너비 제한과 중앙 정렬 스타일이 추가되었으며, 일부 컨테이너 패딩과 높이 조정이 이루어졌습니다.

* **문서화**
  * OTP 입력 컴포넌트 사용법과 다양한 활용 예시를 담은 README 문서가 신규 작성되었습니다.

* **기타**
  * OTP 입력 컴포넌트 관련 신규 패키지 및 의존성이 프로젝트에 추가되어 구성 및 빌드 환경이 업데이트되었습니다.
  * Storybook 빌드 최적화 설정에 OTP 컴포넌트 패키지가 제외되어 빌드 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->