### PR TITLE
[NUGUDI-54] 공용 Grid 컴포넌트 제작 

### DIFF
--- a/packages/react/components/layout/src/index.ts
+++ b/packages/react/components/layout/src/index.ts
@@ -1,5 +1,5 @@
-export type { BoxProps, DividerProps, FlexProps } from "./layout";
-export { Box, Divider, Flex } from "./layout";
+export type { BoxProps, DividerProps, FlexProps, GridProps } from "./layout";
+export { Box, Divider, Flex, Grid } from "./layout";
 export type {
   BodyProps,
   EmphasisProps,

--- a/packages/react/components/layout/src/layout/Grid.tsx
+++ b/packages/react/components/layout/src/layout/Grid.tsx
@@ -1,0 +1,62 @@
+import { vars } from "@nugudi/themes";
+import { clsx } from "clsx";
+import * as React from "react";
+import { BaseStyle, StyleSprinkles } from "../core/style.css";
+import { extractSprinkleProps } from "../utils/properties";
+import type { GridProps } from "./types";
+
+const Grid = (props: GridProps, ref: React.Ref<HTMLElement>) => {
+  const {
+    as = "div",
+    color,
+    background,
+    children,
+    autoColumns,
+    autoFlow,
+    autoRows,
+    columnGap,
+    column,
+    gap,
+    row,
+    rowGap,
+    templateColumns,
+    templateRows,
+    templateAreas,
+  } = props;
+
+  return React.createElement(
+    as,
+    {
+      ...props,
+      ref,
+      className: clsx([
+        BaseStyle,
+        StyleSprinkles(
+          extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
+        ),
+        props.className,
+      ]),
+      style: {
+        display: "grid",
+        gridAutoColumns: autoColumns,
+        gridAutoFlow: autoFlow,
+        gridAutoRows: autoRows,
+        gridColumnGap: columnGap,
+        gridGap: gap,
+        gridRowGap: rowGap,
+        gridTemplateColumns: templateColumns,
+        gridTemplateRows: templateRows,
+        gridTemplateAreas: templateAreas,
+        gridColumn: column,
+        gridRow: row,
+        color: color && vars.colors.$scale?.[color]?.[500],
+        background: background && vars.colors.$scale?.[background]?.[100],
+        ...props.style,
+      },
+    },
+    children,
+  );
+};
+
+const _Grid = React.forwardRef(Grid);
+export { _Grid as Grid };

--- a/packages/react/components/layout/src/layout/index.ts
+++ b/packages/react/components/layout/src/layout/index.ts
@@ -1,5 +1,6 @@
 export { Box } from "./Box";
 export { Divider } from "./Divider";
 export { Flex } from "./Flex";
+export { Grid } from "./Grid";
 
-export type { BoxProps, DividerProps, FlexProps } from "./types";
+export type { BoxProps, DividerProps, FlexProps, GridProps } from "./types";

--- a/packages/react/components/layout/src/layout/types.ts
+++ b/packages/react/components/layout/src/layout/types.ts
@@ -22,3 +22,17 @@ export type FlexProps = {
   wrap?: CSSProperties["flexWrap"];
   gap?: CSSProperties["gap"];
 } & BoxProps;
+
+export type GridProps = {
+  autoColumns?: CSSProperties["gridAutoColumns"];
+  autoFlow?: CSSProperties["gridAutoFlow"];
+  autoRows?: CSSProperties["gridAutoRows"];
+  column?: CSSProperties["gridColumn"];
+  columnGap?: CSSProperties["columnGap"];
+  gap?: CSSProperties["gap"];
+  row?: CSSProperties["gridRow"];
+  rowGap?: CSSProperties["rowGap"];
+  templateAreas?: CSSProperties["gridTemplateAreas"];
+  templateColumns?: CSSProperties["gridTemplateColumns"];
+  templateRows?: CSSProperties["gridTemplateRows"];
+} & BoxProps;

--- a/packages/ui/src/layout/Flex.stories.tsx
+++ b/packages/ui/src/layout/Flex.stories.tsx
@@ -590,7 +590,7 @@ export const GapVariations: Story = {
             background="main"
             padding={3}
             borderRadius="md"
-            textAlign="center"
+            style={{ textAlign: "center" }}
           >
             위 아이템
           </Box>
@@ -599,7 +599,7 @@ export const GapVariations: Story = {
             padding={3}
             borderRadius="md"
             color="whiteAlpha"
-            textAlign="center"
+            style={{ textAlign: "center" }}
           >
             중간 아이템
           </Box>
@@ -607,7 +607,7 @@ export const GapVariations: Story = {
             background="main"
             padding={3}
             borderRadius="md"
-            textAlign="center"
+            style={{ textAlign: "center" }}
           >
             아래 아이템
           </Box>

--- a/packages/ui/src/layout/Grid.stories.tsx
+++ b/packages/ui/src/layout/Grid.stories.tsx
@@ -1,0 +1,480 @@
+import "@nugudi/react-components-layout/style.css";
+import { Grid as _Grid, Box } from "@nugudi/react-components-layout";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof _Grid> = {
+  title: "Components/Layout/Grid",
+  component: _Grid,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    gap: {
+      control: { type: "range", min: 0, max: 24, step: 1 },
+    },
+    columnGap: {
+      control: { type: "range", min: 0, max: 24, step: 1 },
+    },
+    rowGap: {
+      control: { type: "range", min: 0, max: 24, step: 1 },
+    },
+    templateColumns: {
+      control: "text",
+    },
+    templateRows: {
+      control: "text",
+    },
+    templateAreas: {
+      control: "text",
+    },
+    autoFlow: {
+      control: "select",
+      options: ["row", "column", "row dense", "column dense"],
+    },
+    autoColumns: {
+      control: "text",
+    },
+    autoRows: {
+      control: "text",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 그리드 레이아웃
+export const Default: Story = {
+  args: {
+    gap: 4,
+    templateColumns: "repeat(3, 1fr)",
+    padding: 4,
+    background: "whiteAlpha",
+    borderRadius: "lg",
+    style: {
+      width: "400px",
+    },
+  },
+  render: (args) => (
+    <_Grid {...args}>
+      <Box
+        background="main"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        Item 1
+      </Box>
+      <Box
+        background="zinc"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        Item 2
+      </Box>
+      <Box
+        background="blackAlpha"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        Item 3
+      </Box>
+      <Box
+        background="main"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        Item 4
+      </Box>
+      <Box
+        background="zinc"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        Item 5
+      </Box>
+      <Box
+        background="blackAlpha"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        Item 6
+      </Box>
+    </_Grid>
+  ),
+};
+
+// 반응형 컬럼 레이아웃
+export const ResponsiveColumns: Story = {
+  args: {
+    gap: 6,
+    templateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
+    padding: 4,
+    background: "blackAlpha",
+    borderRadius: "xl",
+    style: {
+      width: "500px",
+    },
+  },
+  render: (args) => (
+    <_Grid {...args}>
+      {[
+        "리액트 기초",
+        "Next.js 가이드",
+        "TypeScript 학습",
+        "Tailwind CSS",
+        "Node.js 빠른 시작",
+        "GraphQL 튜토리얼",
+        "Docker 컴테이너",
+        "AWS 배포",
+      ].map((title) => (
+        <Box
+          key={title}
+          background="blackAlpha"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white", textAlign: "center" }}
+        >
+          {title}
+        </Box>
+      ))}
+    </_Grid>
+  ),
+};
+
+// 템플릿 영역을 사용한 레이아웃 (헤더, 사이드바, 메인, 푸터)
+export const TemplateAreas: Story = {
+  args: {
+    gap: 3,
+    templateColumns: "200px 1fr",
+    templateRows: "60px 1fr 40px",
+    templateAreas: `
+      "header header"
+      "sidebar main"
+      "footer footer"
+    `,
+    padding: 4,
+    background: "whiteAlpha",
+    borderRadius: "lg",
+    style: {
+      width: "600px",
+      height: "400px",
+    },
+  },
+  render: (args) => (
+    <_Grid {...args}>
+      <Box
+        background="main"
+        padding={3}
+        borderRadius="md"
+        style={{ gridArea: "header", color: "white" }}
+      >
+        헤더
+      </Box>
+      <Box
+        background="zinc"
+        padding={3}
+        borderRadius="md"
+        style={{ gridArea: "sidebar", color: "white" }}
+      >
+        사이드바
+      </Box>
+      <Box
+        background="blackAlpha"
+        padding={3}
+        borderRadius="md"
+        style={{ gridArea: "main", color: "white" }}
+      >
+        메인 콘텐츠 영역
+      </Box>
+      <Box
+        background="whiteAlpha"
+        padding={3}
+        borderRadius="md"
+        style={{ gridArea: "footer", color: "black" }}
+      >
+        푸터
+      </Box>
+    </_Grid>
+  ),
+};
+
+// 자동 흐름 방향 설정
+export const AutoFlow: Story = {
+  args: {
+    gap: 4,
+    templateColumns: "repeat(3, 100px)",
+    autoFlow: "row",
+    padding: 4,
+    background: "blackAlpha",
+    borderRadius: "lg",
+    style: {
+      width: "400px",
+    },
+  },
+  render: (args) => (
+    <_Grid {...args}>
+      <Box
+        background="main"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        A
+      </Box>
+      <Box
+        background="zinc"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        B
+      </Box>
+      <Box
+        background="blackAlpha"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        C
+      </Box>
+      <Box
+        background="main"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        D
+      </Box>
+      <Box
+        background="zinc"
+        padding={3}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        E
+      </Box>
+    </_Grid>
+  ),
+};
+
+// 간격 설정 변형
+export const GapVariations: Story = {
+  args: {
+    columnGap: 8,
+    rowGap: 2,
+    templateColumns: "repeat(4, 1fr)",
+    padding: 4,
+    background: "whiteAlpha",
+    borderRadius: "lg",
+    style: {
+      width: "400px",
+    },
+  },
+  render: (args) => (
+    <_Grid {...args}>
+      {[1, 2, 3, 4, 5, 6, 7, 8].map((num) => (
+        <Box
+          key={num}
+          background="blackAlpha"
+          padding={2}
+          borderRadius="sm"
+          style={{ color: "white", textAlign: "center" }}
+        >
+          {num}
+        </Box>
+      ))}
+    </_Grid>
+  ),
+};
+
+// 카드 레이아웃
+export const CardLayout: Story = {
+  args: {
+    gap: 6,
+    templateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
+    padding: 6,
+    background: "blackAlpha",
+    borderRadius: "xl",
+    style: {
+      width: "600px",
+    },
+  },
+  render: (args) => (
+    <_Grid {...args}>
+      {[
+        { title: "상품 A", price: "29,000원", bg: "main" },
+        { title: "상품 B", price: "35,000원", bg: "zinc" },
+        { title: "상품 C", price: "42,000원", bg: "blackAlpha" },
+        { title: "상품 D", price: "28,000원", bg: "main" },
+        { title: "상품 E", price: "39,000원", bg: "zinc" },
+        { title: "상품 F", price: "45,000원", bg: "blackAlpha" },
+      ].map((product) => (
+        <Box
+          key={product.title}
+          background={product.bg as "main" | "zinc" | "blackAlpha"}
+          padding={4}
+          borderRadius="lg"
+          style={{
+            color: "white",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+            minHeight: "120px",
+          }}
+        >
+          <div style={{ fontWeight: "bold", fontSize: "14px" }}>
+            {product.title}
+          </div>
+          <div style={{ fontSize: "12px", opacity: 0.9 }}>{product.price}</div>
+        </Box>
+      ))}
+    </_Grid>
+  ),
+};
+
+// 대시보드 레이아웃
+export const Dashboard: Story = {
+  args: {
+    gap: 4,
+    templateColumns: "1fr 1fr 1fr",
+    templateRows: "auto auto 200px",
+    padding: 4,
+    background: "whiteAlpha",
+    borderRadius: "lg",
+    style: {
+      width: "600px",
+    },
+  },
+  render: (args) => (
+    <_Grid {...args}>
+      <Box
+        background="main"
+        padding={4}
+        borderRadius="md"
+        style={{ gridColumn: "1 / -1", color: "white" }}
+      >
+        대시보드 헤더
+      </Box>
+      <Box
+        background="zinc"
+        padding={4}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        통계 1
+      </Box>
+      <Box
+        background="blackAlpha"
+        padding={4}
+        borderRadius="md"
+        style={{ color: "white" }}
+      >
+        통계 2
+      </Box>
+      <Box
+        background="whiteAlpha"
+        padding={4}
+        borderRadius="md"
+        style={{ color: "black" }}
+      >
+        통계 3
+      </Box>
+      <Box
+        background="blackAlpha"
+        padding={4}
+        borderRadius="md"
+        style={{ gridColumn: "1 / -1", color: "white" }}
+      >
+        차트 영역
+      </Box>
+    </_Grid>
+  ),
+};
+
+// 갤러리 레이아웃
+export const Gallery: Story = {
+  args: {
+    gap: 3,
+    templateColumns: "repeat(4, 1fr)",
+    autoRows: "120px",
+    padding: 4,
+    background: "blackAlpha",
+    borderRadius: "lg",
+    style: {
+      width: "500px",
+    },
+  },
+  render: (args) => (
+    <_Grid {...args}>
+      <Box
+        background="main"
+        borderRadius="md"
+        style={{
+          gridColumn: "1 / 3",
+          gridRow: "1 / 3",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "white",
+        }}
+      >
+        대형 이미지
+      </Box>
+      <Box
+        background="zinc"
+        borderRadius="md"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "white",
+        }}
+      >
+        이미지 1
+      </Box>
+      <Box
+        background="blackAlpha"
+        borderRadius="md"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "white",
+        }}
+      >
+        이미지 2
+      </Box>
+      <Box
+        background="whiteAlpha"
+        borderRadius="md"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "black",
+        }}
+      >
+        이미지 3
+      </Box>
+      <Box
+        background="zinc"
+        borderRadius="md"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "white",
+        }}
+      >
+        이미지 4
+      </Box>
+    </_Grid>
+  ),
+};


### PR DESCRIPTION
## 🌀 Issue Number

- #63 

<!-- #NUGUDI-XX Grid 컴포넌트 스토리북 개선 -->

## 😵 As-Is

- Grid 컴포넌트의 스토리북이 단순한 Default 스토리 하나만 존재
- 개발자들이 Grid 컴포넌트의 다양한 활용법을 학습하기 어려운 상황
- 기존 스토리에 타입 에러와 린터 에러가 존재

## 🥳 To-Be

- Grid 컴포넌트의 모든 주요 기능을 다루는 8가지 포괄적인 스토리 추가:
  - **Default**: 기본 3컬럼 그리드 레이아웃
  - **ResponsiveColumns**: 반응형 카드 레이아웃 (`auto-fit`, `minmax` 활용)
  - **TemplateAreas**: 헤더/사이드바/메인/푸터 구조의 웹 애플리케이션 레이아웃
  - **AutoFlow**: 자동 흐름 방향 제어 데모
  - **GapVariations**: columnGap과 rowGap을 다르게 설정한 간격 제어
  - **CardLayout**: 상품 카드 형태의 실용적인 레이아웃
  - **Dashboard**: 통계와 차트 영역이 포함된 대시보드 스타일
  - **Gallery**: 다양한 크기 이미지 배치를 위한 갤러리 레이아웃

- 모든 타입 에러 및 린터 에러 해결:
  - 유효한 색상 값만 사용 (`main`, `zinc`, `whiteAlpha`, `blackAlpha`)
  - JSX 속성 중복 제거
  - 배열 인덱스 대신 고유한 key 값 사용
  - color prop을 style 속성으로 이동하여 타입 안전성 확보

- Storybook 컨트롤 개선:
  - `columnGap`, `rowGap`, `templateColumns`, `templateRows` 등 Grid 관련 모든 속성에 대한 컨트롤 추가
  - 실시간으로 속성 변경 가능한 인터랙티브 환경 제공

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 린터 에러가 모두 해결되었나요?
- [x] 타입 에러가 모두 해결되었나요?

## 📷 Test Screenshot (Optional)
<img width="1793" height="959" alt="스크린샷 2025-08-06 오전 1 13 59" src="https://github.com/user-attachments/assets/5f2bd74f-401c-40d4-866d-61249f0a6650" />
<img width="1794" height="961" alt="스크린샷 2025-08-06 오전 1 14 11" src="https://github.com/user-attachments/assets/7b80844a-67b1-4de7-8bc7-5c7ede457c82" />

<!-- 스토리북에서 각 스토리가 정상적으로 렌더링되는 스크린샷 첨부 가능 -->

## 👾 Additional Description (Optional)
