### PR TITLE
[NUGUDI-55] 공용 GridItem 컴포넌트 생성

### DIFF
--- a/packages/react/components/layout/src/index.ts
+++ b/packages/react/components/layout/src/index.ts
@@ -1,5 +1,11 @@
-export type { BoxProps, DividerProps, FlexProps, GridProps } from "./layout";
-export { Box, Divider, Flex, Grid } from "./layout";
+export type {
+  BoxProps,
+  DividerProps,
+  FlexProps,
+  GridItemProps,
+  GridProps,
+} from "./layout";
+export { Box, Divider, Flex, Grid, GridItem } from "./layout";
 export type {
   BodyProps,
   EmphasisProps,

--- a/packages/react/components/layout/src/layout/GridItem.tsx
+++ b/packages/react/components/layout/src/layout/GridItem.tsx
@@ -1,0 +1,53 @@
+import { vars } from "@nugudi/themes";
+import { clsx } from "clsx";
+import * as React from "react";
+import { BaseStyle, StyleSprinkles } from "../core/style.css";
+import { extractSprinkleProps } from "../utils/properties";
+import type { GridItemProps } from "./types";
+
+const GridItem = (props: GridItemProps, ref: React.Ref<HTMLElement>) => {
+  const {
+    as = "div",
+    color,
+    background,
+    children,
+    area,
+    colEnd,
+    colStart,
+    colSpan,
+    rowEnd,
+    rowStart,
+    rowSpan,
+  } = props;
+
+  return React.createElement(
+    as,
+    {
+      ...props,
+      ref,
+      className: clsx([
+        BaseStyle,
+        StyleSprinkles(
+          extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
+        ),
+        props.className,
+      ]),
+      style: {
+        gridArea: area,
+        gridColumnEnd: colEnd,
+        gridColumnStart: colStart,
+        gridColumn: colSpan,
+        gridRowEnd: rowEnd,
+        gridRowStart: rowStart,
+        gridRow: rowSpan,
+        color: color && vars.colors.$scale?.[color]?.[700],
+        background: background && vars.colors.$scale?.[background]?.[100],
+        ...props.style,
+      },
+    },
+    children,
+  );
+};
+
+const _GridItem = React.forwardRef(GridItem);
+export { _GridItem as GridItem };

--- a/packages/react/components/layout/src/layout/index.ts
+++ b/packages/react/components/layout/src/layout/index.ts
@@ -2,5 +2,12 @@ export { Box } from "./Box";
 export { Divider } from "./Divider";
 export { Flex } from "./Flex";
 export { Grid } from "./Grid";
+export { GridItem } from "./GridItem";
 
-export type { BoxProps, DividerProps, FlexProps, GridProps } from "./types";
+export type {
+  BoxProps,
+  DividerProps,
+  FlexProps,
+  GridItemProps,
+  GridProps,
+} from "./types";

--- a/packages/react/components/layout/src/layout/types.ts
+++ b/packages/react/components/layout/src/layout/types.ts
@@ -36,3 +36,13 @@ export type GridProps = {
   templateColumns?: CSSProperties["gridTemplateColumns"];
   templateRows?: CSSProperties["gridTemplateRows"];
 } & BoxProps;
+
+export type GridItemProps = {
+  area?: CSSProperties["gridArea"];
+  colEnd?: CSSProperties["gridColumnEnd"];
+  colStart?: CSSProperties["gridColumnStart"];
+  colSpan?: CSSProperties["gridColumn"];
+  rowEnd?: CSSProperties["gridRowEnd"];
+  rowStart?: CSSProperties["gridRowStart"];
+  rowSpan?: CSSProperties["gridRow"];
+} & BoxProps;

--- a/packages/ui/src/layout/GridItem.stories.tsx
+++ b/packages/ui/src/layout/GridItem.stories.tsx
@@ -1,0 +1,656 @@
+import "@nugudi/react-components-layout/style.css";
+import { Box, Grid, GridItem } from "@nugudi/react-components-layout";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Layout/GridItem",
+  component: GridItem,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    area: {
+      control: "text",
+      description: "grid-area 속성 값 (예: 'header', 'sidebar', 'content')",
+    },
+    colEnd: {
+      control: { type: "number", min: 1, max: 13 },
+      description: "grid-column-end 속성 값",
+    },
+    colStart: {
+      control: { type: "number", min: 1, max: 13 },
+      description: "grid-column-start 속성 값",
+    },
+    colSpan: {
+      control: { type: "number", min: 1, max: 12 },
+      description: "grid-column span 값",
+    },
+    rowEnd: {
+      control: { type: "number", min: 1, max: 13 },
+      description: "grid-row-end 속성 값",
+    },
+    rowStart: {
+      control: { type: "number", min: 1, max: 13 },
+      description: "grid-row-start 속성 값",
+    },
+    rowSpan: {
+      control: { type: "number", min: 1, max: 12 },
+      description: "grid-row span 값",
+    },
+  },
+} satisfies Meta<typeof GridItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+  render: (args) => (
+    <Grid
+      templateColumns="repeat(3, 1fr)"
+      gap={4}
+      padding={4}
+      background="whiteAlpha"
+      borderRadius="lg"
+      style={{ width: "400px" }}
+    >
+      <GridItem {...args}>
+        <Box
+          background="main"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          Item 1
+        </Box>
+      </GridItem>
+      <GridItem {...args}>
+        <Box
+          background="zinc"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          Item 2
+        </Box>
+      </GridItem>
+      <GridItem {...args}>
+        <Box
+          background="blackAlpha"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          Item 3
+        </Box>
+      </GridItem>
+    </Grid>
+  ),
+};
+
+export const ColumnSpan: Story = {
+  args: {},
+  render: () => (
+    <Grid
+      templateColumns="repeat(4, 1fr)"
+      gap={4}
+      padding={4}
+      background="blackAlpha"
+      borderRadius="lg"
+      style={{ width: "500px" }}
+    >
+      <GridItem colSpan="2">
+        <Box
+          background="main"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          2 칸 차지
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="zinc"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          1 칸
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="whiteAlpha"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "black" }}
+        >
+          1 칸
+        </Box>
+      </GridItem>
+      <GridItem colSpan="3">
+        <Box
+          background="blackAlpha"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          3 칸 차지
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="main"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          1 칸
+        </Box>
+      </GridItem>
+    </Grid>
+  ),
+};
+
+export const RowSpan: Story = {
+  args: {},
+  render: () => (
+    <Grid
+      templateColumns="repeat(3, 1fr)"
+      templateRows="repeat(3, 100px)"
+      gap={4}
+      padding={4}
+      background="whiteAlpha"
+      borderRadius="lg"
+      style={{ width: "400px" }}
+    >
+      <GridItem rowSpan="2">
+        <Box
+          background="main"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white", height: "100%" }}
+        >
+          2 행 차지
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="zinc"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          일반 아이템
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="blackAlpha"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          일반 아이템
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="whiteAlpha"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "black" }}
+        >
+          일반 아이템
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="zinc"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          일반 아이템
+        </Box>
+      </GridItem>
+      <GridItem colSpan="2">
+        <Box
+          background="main"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          2 칸 차지
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="blackAlpha"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white" }}
+        >
+          일반 아이템
+        </Box>
+      </GridItem>
+    </Grid>
+  ),
+};
+
+export const GridArea: Story = {
+  args: {},
+  render: () => (
+    <Grid
+      templateColumns="1fr 2fr 1fr"
+      templateRows="60px 1fr 40px"
+      templateAreas={`
+        "header header header"
+        "sidebar content aside"
+        "footer footer footer"
+      `}
+      gap={3}
+      padding={4}
+      background="blackAlpha"
+      borderRadius="lg"
+      style={{ width: "600px", height: "400px" }}
+    >
+      <GridItem area="header">
+        <Box
+          background="main"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white", height: "100%" }}
+        >
+          헤더 영역
+        </Box>
+      </GridItem>
+      <GridItem area="sidebar">
+        <Box
+          background="zinc"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white", height: "100%" }}
+        >
+          사이드바
+        </Box>
+      </GridItem>
+      <GridItem area="content">
+        <Box
+          background="blackAlpha"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white", height: "100%" }}
+        >
+          메인 콘텐츠
+        </Box>
+      </GridItem>
+      <GridItem area="aside">
+        <Box
+          background="whiteAlpha"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "black", height: "100%" }}
+        >
+          사이드 정보
+        </Box>
+      </GridItem>
+      <GridItem area="footer">
+        <Box
+          background="main"
+          padding={3}
+          borderRadius="md"
+          style={{ color: "white", height: "100%" }}
+        >
+          푸터 영역
+        </Box>
+      </GridItem>
+    </Grid>
+  ),
+};
+
+export const DashboardWidgets: Story = {
+  args: {},
+  render: () => (
+    <Grid
+      templateColumns="repeat(4, 1fr)"
+      templateRows="repeat(3, 120px)"
+      gap={4}
+      padding={4}
+      background="whiteAlpha"
+      borderRadius="lg"
+      style={{ width: "600px" }}
+    >
+      <GridItem colSpan="2" rowSpan="2">
+        <Box
+          background="main"
+          padding={4}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          <h3>매출 차트</h3>
+          <p style={{ fontSize: "24px", marginTop: "16px" }}>₩1,234,567</p>
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="zinc"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          <h4>방문자</h4>
+          <p style={{ fontSize: "20px", marginTop: "8px" }}>1,234</p>
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="blackAlpha"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          <h4>전환율</h4>
+          <p style={{ fontSize: "20px", marginTop: "8px" }}>3.4%</p>
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="whiteAlpha"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "black", height: "100%" }}
+        >
+          <h4>페이지뷰</h4>
+          <p style={{ fontSize: "20px", marginTop: "8px" }}>5,678</p>
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="main"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          <h4>신규 가입</h4>
+          <p style={{ fontSize: "20px", marginTop: "8px" }}>89</p>
+        </Box>
+      </GridItem>
+      <GridItem colSpan="4">
+        <Box
+          background="blackAlpha"
+          padding={4}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          <h3>최근 활동 로그</h3>
+        </Box>
+      </GridItem>
+    </Grid>
+  ),
+};
+
+export const PhotoGallery: Story = {
+  args: {},
+  render: () => (
+    <Grid
+      templateColumns="repeat(4, 1fr)"
+      templateRows="repeat(4, 100px)"
+      gap={3}
+      padding={4}
+      background="blackAlpha"
+      borderRadius="lg"
+      style={{ width: "500px" }}
+    >
+      <GridItem colSpan="2" rowSpan="2">
+        <Box
+          background="main"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "white",
+            fontSize: "18px",
+          }}
+        >
+          대형 이미지
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="zinc"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "white",
+          }}
+        >
+          이미지 1
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="whiteAlpha"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "black",
+          }}
+        >
+          이미지 2
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="blackAlpha"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "white",
+          }}
+        >
+          이미지 3
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="main"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "white",
+          }}
+        >
+          이미지 4
+        </Box>
+      </GridItem>
+      <GridItem colSpan="3">
+        <Box
+          background="zinc"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "white",
+          }}
+        >
+          와이드 이미지
+        </Box>
+      </GridItem>
+      <GridItem rowSpan="2">
+        <Box
+          background="blackAlpha"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "white",
+          }}
+        >
+          세로 이미지
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="whiteAlpha"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "black",
+          }}
+        >
+          이미지 5
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="main"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "white",
+          }}
+        >
+          이미지 6
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          background="zinc"
+          borderRadius="md"
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "white",
+          }}
+        >
+          이미지 7
+        </Box>
+      </GridItem>
+    </Grid>
+  ),
+};
+
+export const ComplexLayout: Story = {
+  args: {},
+  render: () => (
+    <Grid
+      templateColumns="repeat(6, 1fr)"
+      templateRows="repeat(4, 80px)"
+      gap={3}
+      padding={4}
+      background="whiteAlpha"
+      borderRadius="lg"
+      style={{ width: "600px" }}
+    >
+      <GridItem colStart="1" colEnd="4" rowStart="1" rowEnd="3">
+        <Box
+          background="main"
+          padding={4}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          메인 콘텐츠 영역
+        </Box>
+      </GridItem>
+      <GridItem colStart="4" colEnd="7" rowStart="1" rowEnd="2">
+        <Box
+          background="zinc"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          상단 사이드바
+        </Box>
+      </GridItem>
+      <GridItem colStart="4" colEnd="6" rowStart="2" rowEnd="3">
+        <Box
+          background="blackAlpha"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          위젯 1
+        </Box>
+      </GridItem>
+      <GridItem colStart="6" colEnd="7" rowStart="2" rowEnd="4">
+        <Box
+          background="whiteAlpha"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "black", height: "100%" }}
+        >
+          세로 위젯
+        </Box>
+      </GridItem>
+      <GridItem colStart="1" colEnd="3" rowStart="3" rowEnd="5">
+        <Box
+          background="zinc"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          하단 왼쪽
+        </Box>
+      </GridItem>
+      <GridItem colStart="3" colEnd="5" rowStart="3" rowEnd="4">
+        <Box
+          background="main"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          하단 중앙
+        </Box>
+      </GridItem>
+      <GridItem colStart="5" colEnd="6" rowStart="3" rowEnd="4">
+        <Box
+          background="blackAlpha"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "white", height: "100%" }}
+        >
+          작은 위젯
+        </Box>
+      </GridItem>
+      <GridItem colStart="3" colEnd="7" rowStart="4" rowEnd="5">
+        <Box
+          background="whiteAlpha"
+          padding={3}
+          borderRadius="lg"
+          style={{ color: "black", height: "100%" }}
+        >
+          하단 푸터 영역
+        </Box>
+      </GridItem>
+    </Grid>
+  ),
+};


### PR DESCRIPTION
## 🌀 Issue Number
- #65 
<!-- #이슈번호 -->

## 😵 As-Is

  - 레이아웃을 위한 공용 컴포넌트가 부재하여 매번 개별적으로 스타일링 작업이
  필요했습니다.
  - 일관된 레이아웃 시스템 없이 각자 다른 방식으로 구현되어 유지보수가
  어려웠습니다.

<!-- 문제 상황 정의 -->

## 🥳 To-Be

  - GridItem 컴포넌트: Grid 내부 아이템의 세부 배치를 위한 컴포넌트 추가
  - 각 컴포넌트별 Storybook 문서 및 다양한 사용 예제 추가

<!-- 변경 사항 -->

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)
<img width="1443" height="1006" alt="스크린샷 2025-08-06 오전 6 22 45" src="https://github.com/user-attachments/assets/73f3b806-f865-41a4-89d6-ca6243180a2c" />
<img width="1436" height="1001" alt="스크린샷 2025-08-06 오전 6 22 59" src="https://github.com/user-attachments/assets/38ea0a66-2246-4780-84e3-2a339f426a18" />
<img width="1431" height="1007" alt="스크린샷 2025-08-06 오전 6 23 11" src="https://github.com/user-attachments/assets/e4957fb5-5fdf-4e02-8a8f-e495cbe3c5fa" />


## 👾 Additional Description (Optional)

  - GridItem: area, colSpan, rowSpan 등 Grid 아이템 배치 속성 지원


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 새로운 GridItem 컴포넌트가 추가되어 그리드 레이아웃에서 세부 아이템 배치가 가능해졌습니다.
  * GridItemProps 타입이 추가되어 관련 속성(area, colSpan 등)을 활용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->