### PR TITLE
NUGUDI-57] 공용 List 컴포넌트 구현

### DIFF
--- a/packages/react/components/layout/src/index.ts
+++ b/packages/react/components/layout/src/index.ts
@@ -4,8 +4,22 @@ export type {
   FlexProps,
   GridItemProps,
   GridProps,
+  ListItemProps,
+  ListProps,
+  OrderedListProps,
+  UnorderedListProps,
 } from "./layout";
-export { Box, Divider, Flex, Grid, GridItem } from "./layout";
+export {
+  Box,
+  Divider,
+  Flex,
+  Grid,
+  GridItem,
+  List,
+  ListItem,
+  OrderedList,
+  UnorderedList,
+} from "./layout";
 export type {
   BodyProps,
   EmphasisProps,

--- a/packages/react/components/layout/src/layout/List.tsx
+++ b/packages/react/components/layout/src/layout/List.tsx
@@ -3,14 +3,17 @@ import { OrderedList } from "./OrderedList";
 import type { ListProps } from "./types";
 import { UnorderedList } from "./UnOrderedList";
 
-const List = (props: ListProps, ref: React.Ref<HTMLOListElement>) => {
+const List = (
+  props: ListProps,
+  ref: React.Ref<HTMLOListElement | HTMLUListElement>,
+) => {
   const { variant = "unordered", ...rest } = props;
 
   if (variant === "unordered") {
-    return <UnorderedList {...rest} ref={ref} />;
+    return <UnorderedList {...rest} ref={ref as React.Ref<HTMLUListElement>} />;
   }
 
-  return <OrderedList {...rest} ref={ref} />;
+  return <OrderedList {...rest} ref={ref as React.Ref<HTMLOListElement>} />;
 };
 
 const _List = React.forwardRef(List);

--- a/packages/react/components/layout/src/layout/List.tsx
+++ b/packages/react/components/layout/src/layout/List.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { OrderedList } from "./OrderedList";
+import type { ListProps } from "./types";
+import { UnorderedList } from "./UnOrderedList";
+
+const List = (props: ListProps, ref: React.Ref<HTMLOListElement>) => {
+  const { variant = "unordered", ...rest } = props;
+
+  if (variant === "unordered") {
+    return <UnorderedList {...rest} ref={ref} />;
+  }
+
+  return <OrderedList {...rest} ref={ref} />;
+};
+
+const _List = React.forwardRef(List);
+export { _List as List };

--- a/packages/react/components/layout/src/layout/ListItem.tsx
+++ b/packages/react/components/layout/src/layout/ListItem.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { Body } from "../typography";
+import type { ListItemProps } from "./types";
+
+const ListItem = (props: ListItemProps, ref: React.Ref<HTMLLIElement>) => {
+  // TODO: Text 컴포넌트로 변경
+  return <Body {...props} ref={ref} as="li" />;
+};
+
+const _ListItem = React.forwardRef(ListItem);
+export { _ListItem as ListItem };

--- a/packages/react/components/layout/src/layout/OrderedList.tsx
+++ b/packages/react/components/layout/src/layout/OrderedList.tsx
@@ -1,0 +1,26 @@
+import { vars } from "@nugudi/themes";
+import * as React from "react";
+import { Flex } from "./Flex";
+import type { OrderedListProps } from "./types";
+
+const OrderedList = (
+  props: OrderedListProps,
+  ref: React.Ref<HTMLOListElement>,
+) => {
+  const { spacing = 3, children, ...rest } = props;
+
+  return (
+    <Flex
+      {...rest}
+      as="ol"
+      ref={ref}
+      direction="column"
+      style={{ gap: vars.box.spacing[spacing], listStyleType: "decimal" }}
+    >
+      {children}
+    </Flex>
+  );
+};
+
+const _OrderedList = React.forwardRef(OrderedList);
+export { _OrderedList as OrderedList };

--- a/packages/react/components/layout/src/layout/UnOrderedList.tsx
+++ b/packages/react/components/layout/src/layout/UnOrderedList.tsx
@@ -1,0 +1,29 @@
+import { vars } from "@nugudi/themes";
+import * as React from "react";
+import { Flex } from "./Flex";
+import type { UnorderedListProps } from "./types";
+
+const UnorderedList = (
+  props: UnorderedListProps,
+  ref: React.Ref<HTMLOListElement>,
+) => {
+  const { listStyleType = "disc", spacing = 3, children, ...rest } = props;
+
+  return (
+    <Flex
+      {...rest}
+      as="ul"
+      ref={ref}
+      direction="column"
+      style={{
+        gap: vars.box.spacing[spacing],
+        listStyleType: listStyleType as string,
+      }}
+    >
+      {children}
+    </Flex>
+  );
+};
+
+const _UnorderedList = React.forwardRef(UnorderedList);
+export { _UnorderedList as UnorderedList };

--- a/packages/react/components/layout/src/layout/UnOrderedList.tsx
+++ b/packages/react/components/layout/src/layout/UnOrderedList.tsx
@@ -5,7 +5,7 @@ import type { UnorderedListProps } from "./types";
 
 const UnorderedList = (
   props: UnorderedListProps,
-  ref: React.Ref<HTMLOListElement>,
+  ref: React.Ref<HTMLUListElement>,
 ) => {
   const { listStyleType = "disc", spacing = 3, children, ...rest } = props;
 

--- a/packages/react/components/layout/src/layout/index.ts
+++ b/packages/react/components/layout/src/layout/index.ts
@@ -4,6 +4,7 @@ export { Flex } from "./Flex";
 export { Grid } from "./Grid";
 export { GridItem } from "./GridItem";
 export { List } from "./List";
+export { ListItem } from "./ListItem";
 export { OrderedList } from "./OrderedList";
 export type {
   BoxProps,
@@ -11,6 +12,7 @@ export type {
   FlexProps,
   GridItemProps,
   GridProps,
+  ListItemProps,
   ListProps,
   OrderedListProps,
   UnorderedListProps,

--- a/packages/react/components/layout/src/layout/index.ts
+++ b/packages/react/components/layout/src/layout/index.ts
@@ -3,11 +3,16 @@ export { Divider } from "./Divider";
 export { Flex } from "./Flex";
 export { Grid } from "./Grid";
 export { GridItem } from "./GridItem";
-
+export { List } from "./List";
+export { OrderedList } from "./OrderedList";
 export type {
   BoxProps,
   DividerProps,
   FlexProps,
   GridItemProps,
   GridProps,
+  ListProps,
+  OrderedListProps,
+  UnorderedListProps,
 } from "./types";
+export { UnorderedList } from "./UnOrderedList";

--- a/packages/react/components/layout/src/layout/types.ts
+++ b/packages/react/components/layout/src/layout/types.ts
@@ -2,6 +2,7 @@ import type { vars } from "@nugudi/themes";
 import type React from "react";
 import type { CSSProperties } from "react";
 import type { AsElementProps, StyleProps } from "@/core/types";
+import type { BodyProps } from "../typography";
 
 export type BoxProps = AsElementProps & StyleProps;
 
@@ -46,3 +47,15 @@ export type GridItemProps = {
   rowStart?: CSSProperties["gridRowStart"];
   rowSpan?: CSSProperties["gridRow"];
 } & BoxProps;
+
+export type ListProps = {
+  variant?: "unordered" | "ordered";
+  spacing?: keyof typeof vars.box.spacing;
+} & BoxProps;
+
+export type OrderedListProps = Omit<ListProps, "variant">;
+export type ListItemProps = BodyProps;
+
+export type UnorderedListProps = Omit<ListProps, "variant"> & {
+  listStyleType?: CSSProperties["listStyleType"];
+};

--- a/packages/react/components/layout/src/typography/Body.tsx
+++ b/packages/react/components/layout/src/typography/Body.tsx
@@ -8,7 +8,13 @@ import type { BodyProps } from "@/typography/types";
 import { extractSprinkleProps } from "@/utils/properties";
 
 const Body = (props: BodyProps, ref: Ref<HTMLElement>) => {
-  const { as = "p", fontSize, background, color = "main", children } = props;
+  const {
+    as = "p",
+    fontSize,
+    background,
+    color = "blackAlpha",
+    children,
+  } = props;
 
   return React.createElement(
     as,

--- a/packages/ui/src/layout/List.stories.tsx
+++ b/packages/ui/src/layout/List.stories.tsx
@@ -1,0 +1,49 @@
+import "@nugudi/react-components-layout/style.css";
+import {
+  List as _List,
+  ListItem,
+  OrderedList,
+  UnorderedList,
+} from "@nugudi/react-components-layout";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof _List> = {
+  title: "React Components/Layout/List",
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OrderedListStory: Story = {
+  render: () => (
+    <OrderedList spacing={3}>
+      <ListItem fontSize="b1">1번</ListItem>
+      <ListItem fontSize="b2">2번</ListItem>
+      <ListItem fontSize="b3">3번</ListItem>
+    </OrderedList>
+  ),
+};
+
+export const UnorderedListStory: Story = {
+  render: () => (
+    <UnorderedList spacing={3}>
+      <ListItem fontSize="b1">1번</ListItem>
+      <ListItem fontSize="b2">2번</ListItem>
+      <ListItem fontSize="b3">3번</ListItem>
+    </UnorderedList>
+  ),
+};
+
+export const ListStory: Story = {
+  render: () => (
+    <_List variant="ordered" spacing={3}>
+      <ListItem fontSize="b1">1번</ListItem>
+      <ListItem fontSize="b2">2번</ListItem>
+      <ListItem fontSize="b3">3번</ListItem>
+    </_List>
+  ),
+};

--- a/packages/ui/src/layout/List.stories.tsx
+++ b/packages/ui/src/layout/List.stories.tsx
@@ -8,7 +8,7 @@ import {
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const meta: Meta<typeof _List> = {
-  title: "React Components/Layout/List",
+  title: "Components/Layout/List",
   parameters: {
     layout: "centered",
   },


### PR DESCRIPTION
## 🌀 Issue Number
- #67 
<!-- #이슈번호 -->

## 😵 As-Is
NUGUDI  디자인 시스템에 `List` 컴포넌트가 없어서 리스트 형태의 UI를 구현할 때 일관성 있는 스타일링이 어려웠습니다.
<!-- 문제 상황 정의 -->

## 🥳 To-Be
  - List, OrderedList, UnorderedList, ListItem 컴포넌트를 추가했습니다.
  - variant prop을 통해 ordered/unordered 리스트를 선택할 수 있습니다.
  - 스토리북에 List 컴포넌트 사용 예제를 추가했습니다.
  - Body 컴포넌트에 li 태그 지원을 추가했습니다.
<!-- 변경 사항 -->

## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)
<img width="1416" height="996" alt="스크린샷 2025-08-06 오전 8 05 31" src="https://github.com/user-attachments/assets/d0b5eb20-f4dd-4f53-87c7-04862862a70e" />

## 👾 Additional Description (Optional)
  - List 컴포넌트는 variant prop으로 'ordered' | 'unordered'를 받아 올바른 HTML 태그(ol/ul)를 렌더링합니다.
  - ListItem은 Body 컴포넌트를 확장하여 일관된 타이포그래피 스타일을 유지합니다.
  - 모든 컴포넌트는 forwardRef를 지원하여 ref 접근이 가능합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 순서 있는 리스트, 순서 없는 리스트, 리스트 아이템 등 다양한 리스트 컴포넌트가 추가되었습니다.
  * 리스트 컴포넌트는 기본 리스트 유형 선택과 간격 조절 기능을 지원합니다.
  * 새로운 리스트 컴포넌트들은 다양한 스타일과 구조로 사용할 수 있습니다.

* **Documentation**
  * 리스트 컴포넌트 사용 예시가 포함된 Storybook 문서가 추가되었습니다.

* **Style**
  * Body 컴포넌트의 기본 텍스트 색상이 "main"에서 "blackAlpha"로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->