### PR TITLE
[NUGUDI-60] Input 컴포넌트 rightIcon이 들어갈 수 있도록 수정

### DIFF
--- a/packages/react/components/input/src/Input.tsx
+++ b/packages/react/components/input/src/Input.tsx
@@ -5,6 +5,7 @@ import {
   errorMessageStyle,
   inputStyle,
   labelStyle,
+  rightIconStyle,
 } from "./style.css";
 import type { InputProps } from "./types";
 import { useInput } from "./useInput";
@@ -16,6 +17,7 @@ const Input = (props: InputProps, ref: React.Ref<HTMLInputElement>) => {
     label,
     isError,
     errorMessage,
+    rightIcon,
     className,
     style,
     invalid,
@@ -48,11 +50,13 @@ const Input = (props: InputProps, ref: React.Ref<HTMLInputElement>) => {
                 size,
                 variant,
                 isError,
+                hasRightIcon: !!rightIcon,
               }),
             ],
             className,
           )}
         />
+        {rightIcon && <div className={rightIconStyle()}>{rightIcon}</div>}
       </div>
       {isError && errorMessage && (
         <div className={errorMessageStyle()}>{errorMessage}</div>

--- a/packages/react/components/input/src/style.css.ts
+++ b/packages/react/components/input/src/style.css.ts
@@ -94,6 +94,11 @@ export const inputStyle = recipe({
         },
       },
     },
+    hasRightIcon: {
+      true: {
+        paddingRight: "3rem",
+      },
+    },
   },
   compoundVariants: [
     {
@@ -113,5 +118,20 @@ export const errorMessageStyle = recipe({
     ...classes.typography.emphasis.e2,
     color: vars.colors.$static.light.color.red,
     marginTop: "0.25rem",
+  },
+});
+
+export const rightIconStyle = recipe({
+  base: {
+    position: "absolute",
+    right: "0.75rem",
+    top: "50%",
+    transform: "translateY(-50%)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    pointerEvents: "none",
+    width: "24px",
+    height: "24px",
   },
 });

--- a/packages/react/components/input/src/types.ts
+++ b/packages/react/components/input/src/types.ts
@@ -22,4 +22,5 @@ export type InputProps = {
   isError?: boolean;
   errorMessage?: string;
   invalid?: boolean; // aria-invalid용
+  rightIcon?: React.ReactNode;
 } & React.InputHTMLAttributes<HTMLInputElement>;

--- a/packages/ui/src/ReactComponents/Input.stories.tsx
+++ b/packages/ui/src/ReactComponents/Input.stories.tsx
@@ -1,28 +1,78 @@
 import "@nugudi/react-components-input/style.css";
+import { HeartIcon } from "@nugudi/assets-icons";
 import { Input as _Input } from "@nugudi/react-components-input";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const iconOptions = {
+  none: null,
+  heart: <HeartIcon />,
+};
 
 const meta: Meta<typeof _Input> = {
   title: "Components/Input",
   component: _Input,
   tags: ["autodocs"],
   argTypes: {
-    variant: {
-      options: ["default", "filled"],
-      control: "select",
-      defaultValue: "default",
+    label: {
+      control: "text",
+      table: {
+        type: { summary: "string" },
+        category: "Basic",
+      },
+    },
+    placeholder: {
+      control: "text",
+      table: {
+        type: { summary: "string" },
+        category: "Basic",
+      },
     },
     disabled: {
       control: "boolean",
       defaultValue: false,
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "State",
+      },
     },
     isError: {
       control: "boolean",
       defaultValue: false,
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "State",
+      },
     },
     errorMessage: {
       control: "text",
       defaultValue: "",
+      table: {
+        type: { summary: "string" },
+        category: "State",
+      },
+    },
+    variant: {
+      options: ["default", "filled"],
+      control: "select",
+      defaultValue: "default",
+      table: {
+        type: { summary: "default | filled" },
+        defaultValue: { summary: "default" },
+        category: "Appearance",
+      },
+    },
+    rightIcon: {
+      options: Object.keys(iconOptions),
+      mapping: iconOptions,
+      control: { type: "select" },
+      description: "오른쪽에 표시될 아이콘",
+      table: {
+        type: { summary: "ReactNode" },
+        defaultValue: { summary: "none" },
+        category: "Appearance",
+      },
     },
   },
 };
@@ -42,6 +92,22 @@ export const Filled: Story = {
   args: {
     variant: "filled",
     placeholder: "너구리를 입력해주세요.",
+  },
+};
+
+export const DefaultWithRightIcon: Story = {
+  args: {
+    variant: "default",
+    placeholder: "너구리를 입력해주세요.",
+    rightIcon: "heart",
+  },
+};
+
+export const FilledWithRightIcon: Story = {
+  args: {
+    variant: "filled",
+    placeholder: "너구리를 입력해주세요.",
+    rightIcon: "heart",
   },
 };
 
@@ -91,6 +157,11 @@ export const AllStates: Story = {
               errorMessage="전화번호가 올바르지 않습니다"
             />
             <_Input label="비활성화" placeholder="비활성화된 입력" disabled />
+            <_Input
+              label="오른쪽 아이콘"
+              placeholder="너구리를 입력해주세요."
+              rightIcon={<HeartIcon />}
+            />
           </div>
         </div>
 
@@ -102,6 +173,11 @@ export const AllStates: Story = {
             <_Input variant="filled" placeholder="텍스트를 입력하세요" />
             <_Input variant="filled" placeholder="에러 입력" isError={true} />
             <_Input variant="filled" placeholder="비활성화된 입력" disabled />
+            <_Input
+              variant="filled"
+              placeholder="너구리를 입력해주세요."
+              rightIcon={<HeartIcon />}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🌀 Issue Number

<!-- #이슈번호 -->

- #73 

## 😵 As-Is

<!-- 문제 상황 정의 -->

- 닉네임 중복검사 페이지 관련하여 input에 rightIcon이 필요했습니다.

## 🥳 To-Be

<!-- 변경 사항 -->

- Input 컴포넌트 rightIcon이 들어갈 수 있도록 수정
- input 스토리북 카테고리 추가 및 rightIcon 추가 


## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Screenshot (Optional)

<img width="200" height="150" alt="스크린샷 2025-08-09 02 04 33" src="https://github.com/user-attachments/assets/5150c18b-606b-4325-a23e-bf7d7b7d5d10" />

## 👾 Additional Description (Optional)

원래 중복검사 관련 아이콘 이미지를 이 브랜치에서 추가하려 했으나,
apps/web에서 아이콘이 불러와지지 않는 이슈를 발견하여 아래브랜치에서 해당 부분을 수정하게되었습니다.
수정하면서, SVG 추가 작업은 아래 브랜치에서 진행하였습니다.
- #78 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * Input 컴포넌트에 오른쪽 아이콘(rightIcon) 표시 기능이 추가되었습니다.
  * 오른쪽 아이콘이 포함된 Input 컴포넌트의 다양한 예시가 스토리북에 추가되었습니다.

* **Style**
  * 오른쪽 아이콘이 있을 때 입력창의 패딩 및 아이콘 위치 스타일이 개선되었습니다.

* **Documentation**
  * 스토리북에서 오른쪽 아이콘 사용법과 관련된 설명 및 컨트롤 옵션이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->