### PR TITLE
[NUGUDI-95] 비밀번호 찾기 페이지 UI 구현

### DIFF
--- a/apps/web/app/auth/password/forgot/page.tsx
+++ b/apps/web/app/auth/password/forgot/page.tsx
@@ -1,5 +1,7 @@
+import PasswordForgotView from "@/src/domains/auth/password-forgot/ui/views/password-forgot-view";
+
 const PasswordForgotPage = () => {
-  return <div>Password Forgot Page</div>;
+  return <PasswordForgotView />;
 };
 
 export default PasswordForgotPage;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@nugudi/react-components-textarea": "workspace:*",
     "@nugudi/react-hooks-button": "workspace:*",
     "@nugudi/react-hooks-toggle": "workspace:*",
+    "@nugudi/react-hooks-use-stepper": "workspace:*",
     "@nugudi/themes": "workspace:*",
     "@sentry/nextjs": "^9.31.0",
     "@tanstack/react-query": "^5.81.2",

--- a/apps/web/src/domains/auth/password-forgot/constants/password-forgot.ts
+++ b/apps/web/src/domains/auth/password-forgot/constants/password-forgot.ts
@@ -1,0 +1,1 @@
+export const PASSWORD_FORGOT_STORE_KEY = "password-forgot-store";

--- a/apps/web/src/domains/auth/password-forgot/schemas/password-forgot-schema.ts
+++ b/apps/web/src/domains/auth/password-forgot/schemas/password-forgot-schema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+export const passwordForgotSchema = z.object({
+  email: z.email("올바른 이메일 주소를 입력해주세요"),
+  code: z.string().min(6, "올바른 인증 코드를 입력해주세요"),
+  password: z
+    .string()
+    .min(8, "최소 8자 이상 입력해주세요")
+    .max(20, "최대 20자 이하로 입력해주세요")
+    .regex(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]+$/,
+      "영문, 숫자, 특수문자, 대문자를 각각 1개 이상 포함해주세요",
+    ),
+  passwordConfirm: z
+    .string()
+    .min(8, "최소 8자 이상 입력해주세요")
+    .max(20, "최대 20자 이하로 입력해주세요"),
+});
+
+export const passwordForgotEmailSchema = passwordForgotSchema.pick({
+  email: true,
+});
+
+export const passwordForgotEmailVerificationCodeSchema =
+  passwordForgotSchema.pick({
+    code: true,
+  });
+
+export const passwordForgotPasswordSchema = passwordForgotSchema
+  .pick({
+    password: true,
+    passwordConfirm: true,
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    message: "비밀번호가 일치하지 않습니다.",
+    path: ["passwordConfirm"],
+  });
+
+export type PasswordForgotSchema = z.infer<typeof passwordForgotSchema>;
+
+export type PasswordForgotEmailSchema = z.infer<
+  typeof passwordForgotEmailSchema
+>;

--- a/apps/web/src/domains/auth/password-forgot/schemas/password-forgot-schema.ts
+++ b/apps/web/src/domains/auth/password-forgot/schemas/password-forgot-schema.ts
@@ -41,3 +41,11 @@ export type PasswordForgotSchema = z.infer<typeof passwordForgotSchema>;
 export type PasswordForgotEmailSchema = z.infer<
   typeof passwordForgotEmailSchema
 >;
+
+export type PasswordForgotEmailVerificationCodeSchema = z.infer<
+  typeof passwordForgotEmailVerificationCodeSchema
+>;
+
+export type PasswordForgotPasswordSchema = z.infer<
+  typeof passwordForgotPasswordSchema
+>;

--- a/apps/web/src/domains/auth/password-forgot/stores/use-password-forgot-store.ts
+++ b/apps/web/src/domains/auth/password-forgot/stores/use-password-forgot-store.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { PASSWORD_FORGOT_STORE_KEY } from "@/src/domains/auth/password-forgot/constants/password-forgot";
+import type { PasswordForgotSchema } from "@/src/domains/auth/password-forgot/schemas/password-forgot-schema";
+
+type UsePasswordForgotStoreState = Partial<PasswordForgotSchema> & {
+  data: Partial<PasswordForgotSchema>;
+  setData: (data: Partial<PasswordForgotSchema>) => void;
+
+  resetData: () => void;
+};
+
+export const usePasswordForgotStore = create<UsePasswordForgotStoreState>()(
+  persist(
+    (set) => ({
+      data: {},
+
+      setData: (values) =>
+        set((state) => ({
+          data: { ...state.data, ...values },
+        })),
+
+      resetData: () => {
+        localStorage.removeItem(PASSWORD_FORGOT_STORE_KEY);
+        set({ data: {} });
+      },
+    }),
+    {
+      name: PASSWORD_FORGOT_STORE_KEY,
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/index.css.ts
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/index.css.ts
@@ -1,0 +1,7 @@
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  flex: 1,
+  width: "100%",
+  height: "100%",
+});

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/index.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { Flex } from "@nugudi/react-components-layout";
+import { StepIndicator } from "@nugudi/react-components-step-indicator";
 import { useStepper } from "@nugudi/react-hooks-use-stepper";
+import * as styles from "./index.css";
 import { EmailForm } from "./steps/email-form";
 import { EmailVerificationCodeForm } from "./steps/email-verification-code-form";
 import { ResetPasswordForm } from "./steps/reset-password-form";
@@ -14,22 +17,43 @@ const PASSWORD_FORGOT_STEPS = [
 ] as const;
 
 const PasswordForgotForm = () => {
-  const { Step, Stepper } = useStepper<PasswordForgotStep>(
+  const { setStep, Step, Stepper, step } = useStepper<PasswordForgotStep>(
     PASSWORD_FORGOT_STEPS,
   );
 
+  const onChangeStep = (step: 0 | 1 | 2) => {
+    setStep(PASSWORD_FORGOT_STEPS[step]);
+  };
+
   return (
-    <Stepper>
-      <Step name="이메일_입력">
-        <EmailForm />
-      </Step>
-      <Step name="인증번호_입력">
-        <EmailVerificationCodeForm />
-      </Step>
-      <Step name="새_비밀번호_입력">
-        <ResetPasswordForm />
-      </Step>
-    </Stepper>
+    <Flex
+      direction="column"
+      align="center"
+      justify="center"
+      className={styles.container}
+    >
+      <StepIndicator
+        currentStep={PASSWORD_FORGOT_STEPS.indexOf(step) + 1}
+        totalSteps={PASSWORD_FORGOT_STEPS.length}
+      />
+      <Stepper>
+        <Step name="이메일_입력">
+          <EmailForm onNext={() => onChangeStep(1)} />
+        </Step>
+        <Step name="인증번호_입력">
+          <EmailVerificationCodeForm
+            onPrevious={() => onChangeStep(0)}
+            onNext={() => onChangeStep(2)}
+          />
+        </Step>
+        <Step name="새_비밀번호_입력">
+          <ResetPasswordForm
+            onPrevious={() => onChangeStep(1)}
+            onSubmit={() => console.log("submit")}
+          />
+        </Step>
+      </Stepper>
+    </Flex>
   );
 };
 

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useStepper } from "@nugudi/react-hooks-use-stepper";
+import { EmailForm } from "./steps/email-form";
+import { EmailVerificationCodeForm } from "./steps/email-verification-code-form";
+import { ResetPasswordForm } from "./steps/reset-password-form";
+
+type PasswordForgotStep = typeof PASSWORD_FORGOT_STEPS;
+
+const PASSWORD_FORGOT_STEPS = [
+  "이메일_입력",
+  "인증번호_입력",
+  "새_비밀번호_입력",
+] as const;
+
+const PasswordForgotForm = () => {
+  const { Step, Stepper } = useStepper<PasswordForgotStep>(
+    PASSWORD_FORGOT_STEPS,
+  );
+
+  return (
+    <Stepper>
+      <Step name="이메일_입력">
+        <EmailForm />
+      </Step>
+      <Step name="인증번호_입력">
+        <EmailVerificationCodeForm />
+      </Step>
+      <Step name="새_비밀번호_입력">
+        <ResetPasswordForm />
+      </Step>
+    </Stepper>
+  );
+};
+
+export default PasswordForgotForm;

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/index.tsx
@@ -3,6 +3,7 @@
 import { Flex } from "@nugudi/react-components-layout";
 import { StepIndicator } from "@nugudi/react-components-step-indicator";
 import { useStepper } from "@nugudi/react-hooks-use-stepper";
+import { useRouter } from "next/navigation";
 import * as styles from "./index.css";
 import { EmailForm } from "./steps/email-form";
 import { EmailVerificationCodeForm } from "./steps/email-verification-code-form";
@@ -17,6 +18,8 @@ const PASSWORD_FORGOT_STEPS = [
 ] as const;
 
 const PasswordForgotForm = () => {
+  const router = useRouter();
+
   const { setStep, Step, Stepper, step } = useStepper<PasswordForgotStep>(
     PASSWORD_FORGOT_STEPS,
   );
@@ -49,7 +52,10 @@ const PasswordForgotForm = () => {
         <Step name="새_비밀번호_입력">
           <ResetPasswordForm
             onPrevious={() => onChangeStep(1)}
-            onSubmit={() => console.log("submit")}
+            onSubmit={() => {
+              alert("비밀번호 변경 완료");
+              router.push("/");
+            }}
           />
         </Step>
       </Stepper>

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.css.ts
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.css.ts
@@ -1,0 +1,17 @@
+import { style } from "@vanilla-extract/css";
+
+export const form = style({
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+  flex: 1,
+});
+
+export const titleContainer = style({
+  marginTop: "32px",
+});
+
+export const inputContainer = style({
+  flex: 1,
+  marginTop: "32px",
+});

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.tsx
@@ -1,3 +1,4 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@nugudi/react-components-button";
 import { Input } from "@nugudi/react-components-input";
 import {
@@ -7,6 +8,11 @@ import {
   Title,
   VStack,
 } from "@nugudi/react-components-layout";
+import { useForm } from "react-hook-form";
+import {
+  type SignUpEmailSchema,
+  signUpEmailSchema,
+} from "@/src/domains/auth/sign-up/schemas/sign-up-schema";
 import * as styles from "./index.css";
 
 interface EmailFormProps {
@@ -14,8 +20,22 @@ interface EmailFormProps {
 }
 
 export const EmailForm = ({ onNext }: EmailFormProps) => {
+  const form = useForm<SignUpEmailSchema>({
+    resolver: zodResolver(signUpEmailSchema),
+    defaultValues: {
+      email: "",
+    },
+    mode: "onTouched",
+  });
+
+  const onSubmit = (data: SignUpEmailSchema) => {
+    // TODO: 데이터 전역 상태 저장.
+    console.log(data);
+    onNext();
+  };
+
   return (
-    <form onSubmit={onNext} className={styles.form}>
+    <form onSubmit={form.handleSubmit(onSubmit)} className={styles.form}>
       <Box className={styles.titleContainer}>
         <Flex direction="column" justify="start" align="start">
           <VStack gap={5}>
@@ -35,9 +55,9 @@ export const EmailForm = ({ onNext }: EmailFormProps) => {
       <Box className={styles.inputContainer}>
         <Input
           placeholder="이메일"
-          // {...form.register("email")}
-          // isError={!!form.formState.errors.email}
-          // errorMessage={form.formState.errors.email?.message}
+          {...form.register("email")}
+          isError={!!form.formState.errors.email}
+          errorMessage={form.formState.errors.email?.message}
         />
       </Box>
 

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.tsx
@@ -10,9 +10,10 @@ import {
 } from "@nugudi/react-components-layout";
 import { useForm } from "react-hook-form";
 import {
-  type SignUpEmailSchema,
-  signUpEmailSchema,
-} from "@/src/domains/auth/sign-up/schemas/sign-up-schema";
+  type PasswordForgotEmailSchema,
+  passwordForgotEmailSchema,
+} from "@/src/domains/auth/password-forgot/schemas/password-forgot-schema";
+import { usePasswordForgotStore } from "@/src/domains/auth/password-forgot/stores/use-password-forgot-store";
 import * as styles from "./index.css";
 
 interface EmailFormProps {
@@ -20,17 +21,21 @@ interface EmailFormProps {
 }
 
 export const EmailForm = ({ onNext }: EmailFormProps) => {
-  const form = useForm<SignUpEmailSchema>({
-    resolver: zodResolver(signUpEmailSchema),
+  const { setData, data } = usePasswordForgotStore();
+
+  const form = useForm<PasswordForgotEmailSchema>({
+    resolver: zodResolver(passwordForgotEmailSchema),
     defaultValues: {
-      email: "",
+      email: data.email ?? "",
     },
     mode: "onTouched",
   });
 
-  const onSubmit = (data: SignUpEmailSchema) => {
-    // TODO: 데이터 전역 상태 저장.
-    console.log(data);
+  const onSubmit = (data: PasswordForgotEmailSchema) => {
+    setData({
+      ...data,
+      email: data.email,
+    });
     onNext();
   };
 

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.tsx
@@ -1,3 +1,49 @@
-export const EmailForm = () => {
-  return <div>Email Form</div>;
+import { Button } from "@nugudi/react-components-button";
+import { Input } from "@nugudi/react-components-input";
+import {
+  Body,
+  Box,
+  Flex,
+  Title,
+  VStack,
+} from "@nugudi/react-components-layout";
+import * as styles from "./index.css";
+
+interface EmailFormProps {
+  onNext: () => void;
+}
+
+export const EmailForm = ({ onNext }: EmailFormProps) => {
+  return (
+    <form onSubmit={onNext} className={styles.form}>
+      <Box className={styles.titleContainer}>
+        <Flex direction="column" justify="start" align="start">
+          <VStack gap={5}>
+            <Title fontSize="t1" color="zinc">
+              이메일을 입력해주세요
+            </Title>
+            <Body fontSize="b3" color="zinc">
+              가입한 이메일 주소를 입력해주세요.
+            </Body>
+            <Body fontSize="b3" color="zinc">
+              메일로 인증번호를 보내드려요 (스팸 메일함도 확인)
+            </Body>
+          </VStack>
+        </Flex>
+      </Box>
+
+      <Box className={styles.inputContainer}>
+        <Input
+          placeholder="이메일"
+          // {...form.register("email")}
+          // isError={!!form.formState.errors.email}
+          // errorMessage={form.formState.errors.email?.message}
+        />
+      </Box>
+
+      <Button width="full" type="submit" color="zinc" variant="brand" size="lg">
+        다음
+      </Button>
+    </form>
+  );
 };

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-form/index.tsx
@@ -1,0 +1,3 @@
+export const EmailForm = () => {
+  return <div>Email Form</div>;
+};

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-verification-code-form/index.css.ts
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-verification-code-form/index.css.ts
@@ -1,0 +1,17 @@
+import { style } from "@vanilla-extract/css";
+
+export const form = style({
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+  flex: 1,
+});
+
+export const titleContainer = style({
+  marginTop: "32px",
+});
+
+export const inputOtpContainer = style({
+  flex: 1,
+  marginTop: "32px",
+});

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-verification-code-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-verification-code-form/index.tsx
@@ -1,0 +1,3 @@
+export const EmailVerificationCodeForm = () => {
+  return <div>Email Verification Code Form</div>;
+};

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-verification-code-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-verification-code-form/index.tsx
@@ -1,3 +1,19 @@
-export const EmailVerificationCodeForm = () => {
-  return <div>Email Verification Code Form</div>;
+import { Button } from "@nugudi/react-components-button";
+import { VStack } from "@nugudi/react-components-layout";
+
+interface EmailVerificationCodeFormProps {
+  onPrevious: () => void;
+  onNext: () => void;
+}
+
+export const EmailVerificationCodeForm = ({
+  onPrevious,
+  onNext,
+}: EmailVerificationCodeFormProps) => {
+  return (
+    <VStack>
+      <Button onClick={onPrevious}>이전</Button>
+      <Button onClick={onNext}>다음</Button>
+    </VStack>
+  );
 };

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-verification-code-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/email-verification-code-form/index.tsx
@@ -1,5 +1,20 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@nugudi/react-components-button";
-import { VStack } from "@nugudi/react-components-layout";
+import { InputOTP } from "@nugudi/react-components-input-otp";
+import {
+  Box,
+  Flex,
+  HStack,
+  Title,
+  VStack,
+} from "@nugudi/react-components-layout";
+import { useForm } from "react-hook-form";
+import {
+  type PasswordForgotEmailVerificationCodeSchema,
+  passwordForgotEmailVerificationCodeSchema,
+} from "@/src/domains/auth/password-forgot/schemas/password-forgot-schema";
+import { usePasswordForgotStore } from "@/src/domains/auth/password-forgot/stores/use-password-forgot-store";
+import * as styles from "./index.css";
 
 interface EmailVerificationCodeFormProps {
   onPrevious: () => void;
@@ -10,10 +25,69 @@ export const EmailVerificationCodeForm = ({
   onPrevious,
   onNext,
 }: EmailVerificationCodeFormProps) => {
+  const { setData, data } = usePasswordForgotStore();
+
+  const form = useForm<PasswordForgotEmailVerificationCodeSchema>({
+    resolver: zodResolver(passwordForgotEmailVerificationCodeSchema),
+    defaultValues: {
+      code: data.code ?? "",
+    },
+    mode: "onTouched",
+  });
+
+  const onSubmit = (data: PasswordForgotEmailVerificationCodeSchema) => {
+    setData({
+      ...data,
+      code: data.code,
+    });
+    onNext();
+  };
+
   return (
-    <VStack>
-      <Button onClick={onPrevious}>이전</Button>
-      <Button onClick={onNext}>다음</Button>
-    </VStack>
+    <form onSubmit={form.handleSubmit(onSubmit)} className={styles.form}>
+      <Box className={styles.titleContainer}>
+        <Flex direction="column" justify="start" align="start">
+          <VStack gap={5}>
+            <Title fontSize="t1" color="zinc">
+              인증 번호를 입력해주세요
+            </Title>
+          </VStack>
+        </Flex>
+      </Box>
+
+      <Box className={styles.inputOtpContainer}>
+        <InputOTP
+          length={6}
+          value={form.watch("code")}
+          isError={!!form.formState.errors.code}
+          errorMessage={form.formState.errors.code?.message}
+          onChange={(value) => {
+            form.setValue("code", value);
+          }}
+        />
+      </Box>
+
+      <HStack gap={5}>
+        <Button
+          type="button"
+          color="zinc"
+          variant="neutral"
+          size="lg"
+          onClick={onPrevious}
+          width="full"
+        >
+          이전
+        </Button>
+        <Button
+          type="submit"
+          color="zinc"
+          variant="brand"
+          size="lg"
+          width="full"
+        >
+          다음
+        </Button>
+      </HStack>
+    </form>
   );
 };

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/reset-password-form/index.css.ts
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/reset-password-form/index.css.ts
@@ -1,0 +1,25 @@
+import { style } from "@vanilla-extract/css";
+
+export const form = style({
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+  height: "100%",
+  flex: 1,
+});
+
+export const titleContainer = style({
+  marginTop: "32px",
+});
+
+export const descriptionContainer = style({
+  marginTop: "12px",
+});
+
+export const inputContainer = style({
+  flex: 1,
+  marginTop: "32px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "42px",
+});

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/reset-password-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/reset-password-form/index.tsx
@@ -1,5 +1,16 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { EyeIcon, EyeOffIcon } from "@nugudi/assets-icons";
 import { Button } from "@nugudi/react-components-button";
-import { VStack } from "@nugudi/react-components-layout";
+import { Input } from "@nugudi/react-components-input";
+import { Body, Box, HStack, Title } from "@nugudi/react-components-layout";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import {
+  type PasswordForgotPasswordSchema,
+  passwordForgotPasswordSchema,
+} from "@/src/domains/auth/password-forgot/schemas/password-forgot-schema";
+import { usePasswordForgotStore } from "@/src/domains/auth/password-forgot/stores/use-password-forgot-store";
+import * as styles from "./index.css";
 
 interface ResetPasswordFormProps {
   onPrevious: () => void;
@@ -10,10 +21,132 @@ export const ResetPasswordForm = ({
   onPrevious,
   onSubmit,
 }: ResetPasswordFormProps) => {
+  const { setData, data } = usePasswordForgotStore();
+
+  const [visibilityState, setVisibilityState] = useState({
+    password: false,
+    passwordConfirm: false,
+  });
+
+  const form = useForm({
+    resolver: zodResolver(passwordForgotPasswordSchema),
+    defaultValues: {
+      password: data.password ?? "",
+      passwordConfirm: data.passwordConfirm ?? "",
+    },
+    mode: "onTouched",
+  });
+
+  const onNext = (data: PasswordForgotPasswordSchema) => {
+    setData({
+      ...data,
+      password: data.password,
+      passwordConfirm: data.passwordConfirm,
+    });
+    onSubmit();
+  };
+
+  const togglePasswordVisibility = () => {
+    setVisibilityState({
+      ...visibilityState,
+      password: !visibilityState.password,
+    });
+  };
+
   return (
-    <VStack>
-      <Button onClick={onPrevious}>이전</Button>
-      <Button onClick={onSubmit}>제출</Button>
-    </VStack>
+    <form onSubmit={form.handleSubmit(onNext)} className={styles.form}>
+      <Box className={styles.titleContainer}>
+        <Title fontSize="t1" color="zinc">
+          비밀번호를 입력해주세요
+        </Title>
+        <Box className={styles.descriptionContainer}>
+          <Body fontSize="b3" color="zinc">
+            최소 8자 이상, 최대 20자 이하
+          </Body>
+          <Body fontSize="b3" color="zinc">
+            영문/숫자/특수문자/대문자 1개 이상을 포함해주세요
+          </Body>
+        </Box>
+      </Box>
+
+      <Box className={styles.inputContainer}>
+        <Input
+          label="비밀번호"
+          placeholder="최소 8자 이상, 최대 20자 이하"
+          {...form.register("password")}
+          isError={!!form.formState.errors.password}
+          errorMessage={form.formState.errors.password?.message}
+          type={visibilityState.password ? "text" : "password"}
+          rightIcon={
+            <button
+              type="button"
+              aria-label={
+                visibilityState.password ? "비밀번호 숨기기" : "비밀번호 보기"
+              }
+              aria-pressed={visibilityState.password}
+              onClick={togglePasswordVisibility}
+              style={{
+                cursor: "pointer",
+                pointerEvents: "auto",
+                background: "none",
+                border: "none",
+              }}
+            >
+              {visibilityState.password ? <EyeOffIcon /> : <EyeIcon />}
+            </button>
+          }
+        />
+        <Input
+          label="비밀번호 확인"
+          placeholder="새 비밀번호를 입력해주세요"
+          {...form.register("passwordConfirm")}
+          isError={!!form.formState.errors.passwordConfirm}
+          errorMessage={form.formState.errors.passwordConfirm?.message}
+          type={visibilityState.passwordConfirm ? "text" : "password"}
+          rightIcon={
+            <button
+              type="button"
+              aria-label={
+                visibilityState.passwordConfirm
+                  ? "비밀번호 확인 숨기기"
+                  : "비밀번호 확인 보기"
+              }
+              aria-pressed={visibilityState.passwordConfirm}
+              onClick={togglePasswordVisibility}
+              style={{
+                cursor: "pointer",
+                pointerEvents: "auto",
+                background: "none",
+                border: "none",
+              }}
+            >
+              {visibilityState.passwordConfirm ? <EyeOffIcon /> : <EyeIcon />}
+            </button>
+          }
+        />
+      </Box>
+
+      <HStack gap={5}>
+        <Button
+          type="button"
+          color="zinc"
+          variant="neutral"
+          size="lg"
+          onClick={onPrevious}
+          width="full"
+        >
+          이전
+        </Button>
+        <Button
+          type="submit"
+          color="main"
+          variant="brand"
+          size="lg"
+          width="full"
+        >
+          비밀번호 변경
+        </Button>
+      </HStack>
+    </form>
   );
 };

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/reset-password-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/reset-password-form/index.tsx
@@ -1,3 +1,19 @@
-export const ResetPasswordForm = () => {
-  return <div>Reset Password Form</div>;
+import { Button } from "@nugudi/react-components-button";
+import { VStack } from "@nugudi/react-components-layout";
+
+interface ResetPasswordFormProps {
+  onPrevious: () => void;
+  onSubmit: () => void;
+}
+
+export const ResetPasswordForm = ({
+  onPrevious,
+  onSubmit,
+}: ResetPasswordFormProps) => {
+  return (
+    <VStack>
+      <Button onClick={onPrevious}>이전</Button>
+      <Button onClick={onSubmit}>제출</Button>
+    </VStack>
+  );
 };

--- a/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/reset-password-form/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/components/password-forgot-form/steps/reset-password-form/index.tsx
@@ -1,0 +1,3 @@
+export const ResetPasswordForm = () => {
+  return <div>Reset Password Form</div>;
+};

--- a/apps/web/src/domains/auth/password-forgot/ui/sections/password-forgot-section/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/sections/password-forgot-section/index.tsx
@@ -1,0 +1,7 @@
+import PasswordForgotForm from "@/src/domains/auth/password-forgot/ui/components/password-forgot-form";
+
+const PasswordForgotSection = () => {
+  return <PasswordForgotForm />;
+};
+
+export default PasswordForgotSection;

--- a/apps/web/src/domains/auth/password-forgot/ui/views/password-forgot-view/index.css.ts
+++ b/apps/web/src/domains/auth/password-forgot/ui/views/password-forgot-view/index.css.ts
@@ -3,6 +3,7 @@ import { style } from "@vanilla-extract/css";
 export const container = style({
   width: "100%",
   minHeight: "100vh",
+  display: "flex",
   flexDirection: "column",
   boxSizing: "border-box",
   padding: "16px",

--- a/apps/web/src/domains/auth/password-forgot/ui/views/password-forgot-view/index.css.ts
+++ b/apps/web/src/domains/auth/password-forgot/ui/views/password-forgot-view/index.css.ts
@@ -1,0 +1,9 @@
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  width: "100%",
+  minHeight: "100vh",
+  flexDirection: "column",
+  boxSizing: "border-box",
+  padding: "16px",
+});

--- a/apps/web/src/domains/auth/password-forgot/ui/views/password-forgot-view/index.tsx
+++ b/apps/web/src/domains/auth/password-forgot/ui/views/password-forgot-view/index.tsx
@@ -1,0 +1,15 @@
+import { Flex } from "@nugudi/react-components-layout";
+import PasswordForgotSection from "@/src/domains/auth/password-forgot/ui/sections/password-forgot-section";
+import NavBar from "@/src/shared/ui/components/nav-bar";
+import * as styles from "./index.css";
+
+const PasswordForgotView = () => {
+  return (
+    <Flex direction="column" align="start" className={styles.container}>
+      <NavBar />
+      <PasswordForgotSection />
+    </Flex>
+  );
+};
+
+export default PasswordForgotView;

--- a/apps/web/src/shared/ui/components/mobile-first-layout/index.tsx
+++ b/apps/web/src/shared/ui/components/mobile-first-layout/index.tsx
@@ -10,7 +10,7 @@ interface MobileFirstLayoutProps {
 }
 
 // TabBar를 표시할 경로들
-const TAB_BAR_PATHS = ["/", "/benefits", "/auth/my", "/auth/password/forgot"];
+const TAB_BAR_PATHS = ["/", "/benefits", "/auth/my"];
 
 const MobileFirstLayout = ({ children }: MobileFirstLayoutProps) => {
   const pathname = usePathname();

--- a/apps/web/src/shared/ui/components/mobile-first-layout/index.tsx
+++ b/apps/web/src/shared/ui/components/mobile-first-layout/index.tsx
@@ -10,7 +10,7 @@ interface MobileFirstLayoutProps {
 }
 
 // TabBar를 표시할 경로들
-const TAB_BAR_PATHS = ["/", "/benefits", "/auth/my"];
+const TAB_BAR_PATHS = ["/", "/benefits", "/auth/my", "/auth/password/forgot"];
 
 const MobileFirstLayout = ({ children }: MobileFirstLayoutProps) => {
   const pathname = usePathname();

--- a/packages/react/hooks/use-stepper/src/useStepper.ts
+++ b/packages/react/hooks/use-stepper/src/useStepper.ts
@@ -3,14 +3,14 @@ import type { StepProps, StepperProps } from "./types";
 
 /**
  * @param steps - The steps to use in the stepper.
- * @returns The Stepper, Step, and setStep functions.
+ * @returns The Stepper, Step, setStep, and step functions.
  * @example
  * ```tsx
  * export type StepType = typeof SIGNUP_REGISTRATION_STEPS;
  *
  * const SIGNUP_REGISTRATION_STEPS = ["이름_입력", "이메일_입력", "비밀번호_입력", "비밀번호_확인", "전화번호_입력"] as const;
  *
- * const { Stepper, Step, setStep } = useStepper<StepType>(SIGNUP_REGISTRATION_STEPS);
+ * const { Stepper, Step, setStep, step } = useStepper<StepType>(SIGNUP_REGISTRATION_STEPS);
  *
  * return (
  *   <Stepper>
@@ -39,5 +39,5 @@ export const useStepper = <T extends readonly string[]>(steps: T) => {
     return React.createElement(React.Fragment, null, targetStep);
   });
 
-  return { Stepper, Step, setStep };
+  return { Stepper, Step, setStep, step };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@nugudi/react-hooks-toggle':
         specifier: workspace:*
         version: link:../../packages/react/hooks/toggle
+      '@nugudi/react-hooks-use-stepper':
+        specifier: workspace:*
+        version: link:../../packages/react/hooks/use-stepper
       '@nugudi/themes':
         specifier: workspace:*
         version: link:../../packages/themes


### PR DESCRIPTION
## 🌀 Issue Number
- #104 
<!-- #이슈번호 -->

## 😵 As-Is
  - 비밀번호 찾기 기능이 구현되어 있지 않음
  - 페이지 이동 시 입력했던 데이터가 유지되지 않음
<!-- 문제 상황 정의 -->

## 🥳 To-Be
  - 비밀번호 찾기 기능 완전 구현
    - 이메일 입력 → 인증 코드 확인 → 새 비밀번호 설정의 3단계 Flow 구현
    - React Hook Form을 활용한 폼 관리 및 유효성 검증
    - Zustand를 활용한 단계별 상태 관리
    - 반응형 UI 및 컴포넌트 모듈화
  - 회원가입 UX 개선
    - 첫번째, 마지막 페이지를 제외한 모든 단계에 이전 버튼 추가
    - 약관 동의 기능 완전 구현 (필수/선택 약관 구분)
    - 페이지 이동 시 이메일, 인증 코드, 비밀번호 데이터 유지 기능
  - 공통 컴포넌트 개선
    - Agreement 컴포넌트 신규 구현
    - Button 컴포넌트 타입 및 스타일 확장
    - useStepper 훅 기능 개선
<!-- 변경 사항 -->

## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)
<img width="605" height="963" alt="스크린샷 2025-08-17 오후 8 01 45" src="https://github.com/user-attachments/assets/37dd7674-a1b7-4abf-8ff0-4f7b16f4a946" />

<img width="607" height="967" alt="스크린샷 2025-08-17 오후 8 01 57" src="https://github.com/user-attachments/assets/17335190-6ac9-4a2f-9af7-4cd92e3146fe" />

<img width="622" height="958" alt="스크린샷 2025-08-17 오후 8 02 08" src="https://github.com/user-attachments/assets/e55ed68e-ccf2-4ce5-9602-7609987b392c" />

## 👾 Additional Description (Optional)
  1. 비밀번호 찾기 도메인 신규 구현
    - /auth/password/forgot 페이지 및 관련 컴포넌트 구조 완전 구현
    - 3단계 Flow: EmailForm → EmailVerificationCodeForm → ResetPasswordForm
    - 각 단계별 스키마 검증 및 상태 관리
  2. 회원가입 UX 대폭 개선
    - 단계별 이전 버튼 로직 구현
    - 약관 동의 타입 정의 및 UI 구현
    - 데이터 지속성 보장 로직 추가
  3. 코드 품질 향상
    - 도메인별 폴더 구조 체계화
    - TypeScript 타입 안정성 강화
    - 재사용 가능한 컴포넌트 분리
    
    @hijjoy 회원가입 부분은, 완전히 zustand로 관리를 했는데 개인적으로 너무 하나의 전역상태에서 많은 역할을 한다고 생각하여, useStepper 훅을 만들어서 이번 password form은 관심사분리를 통해 작업을 해보았습니다.
    useStepper는 스텝이동, 스텝 등 정말 step에 관련된 역할을 진행하며 최대한 type safety 하게 만들었습니다. zustand는 뒤로가기시 유저의 데이터를 보관하기 위하여 정말 데이터를 보존하는 store의 역할만 진행하게 만들었습니다.
    
    어떤게 더 개인적으로 좋아보이는지 궁금합니다!