### PR TITLE
[NUGUDI-97] Box 컴포넌트에서 boxShadow prop이 DOM으로 전달되는 문제 수정

### DIFF
--- a/apps/web/src/domains/auth/my/ui/sections/profile-section/index.tsx
+++ b/apps/web/src/domains/auth/my/ui/sections/profile-section/index.tsx
@@ -10,6 +10,7 @@ const ProfileSection = () => {
   return (
     <Flex className={styles.container}>
       <Image
+        priority
         src="/images/nuguri.webp"
         alt="profile"
         width={60}

--- a/packages/react/components/layout/src/layout/Box.tsx
+++ b/packages/react/components/layout/src/layout/Box.tsx
@@ -12,6 +12,7 @@ const Box = (props: BoxProps, ref: React.Ref<HTMLElement>) => {
     background,
     borderRadius,
     padding,
+    boxShadow,
     children,
     ...restProps
   } = props;
@@ -33,6 +34,7 @@ const Box = (props: BoxProps, ref: React.Ref<HTMLElement>) => {
         background: background && vars.colors.$scale?.[background]?.[500],
         borderRadius: borderRadius && vars.box.radii?.[borderRadius],
         padding: padding && vars.box.spacing?.[padding],
+        boxShadow: boxShadow && vars.box.shadows?.[boxShadow],
         ...props.style,
       },
     },


### PR DESCRIPTION
## 🌀 Issue Number
- #107 
<!-- #이슈번호 -->

## 😵 As-Is
`Box` 컴포넌트에서 `boxShadow` prop이 DOM에 직접 전달되어 React 경고 발생
<!-- 문제 상황 정의 -->

## 🥳 To-Be
`boxShadow prop`을 구조 분해 할당으로 추출하여 DOM 전달 방지 및 style 객체 내에서 처리
<!-- 변경 사항 -->

## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)

## 👾 Additional Description (Optional)
@hijjoy 추가로, `/auth/my` 에서 쓰이는 이미지가 priority warning이 발생해서 이 부분도 이번 커밋에서 함께 해결했습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Box 컴포넌트에 boxShadow 속성 지원을 추가했습니다. 테마 섀도 토큰과 연동되어 간편하게 그림자 스타일을 적용할 수 있습니다.

- 성능 개선
  - 프로필 섹션의 프로필 이미지를 우선 로딩하도록 변경했습니다. 초기 화면에서 이미지가 더 빠르게 표시되어 체감 응답성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->