### PR TITLE
[NUGUDI-113] color 스토리북 리팩토링 

### DIFF
--- a/.cursor/rules/packages.md
+++ b/.cursor/rules/packages.md
@@ -12,6 +12,15 @@ This is a **Turbo-powered pnpm workspace monorepo** with a **Design System-first
 nugudi/
 ├── apps/                    # Applications
 │   └── web/                # Next.js 15 + React 19 (Main Web App)
+│       └── app/           # Next.js App Router
+│           ├── (auth)/    # 🔒 Protected routes - Require authentication
+│           │   ├── benefits/     # Benefits page (authenticated users only)
+│           │   └── my/          # My page/profile (authenticated users only)
+│           └── (public)/  # 🌍 Public routes - No authentication required
+│               ├── auth/        # Auth-related public pages
+│               │   ├── sign-in/ # Sign in page
+│               │   └── sign-up/ # Sign up page
+│               └── home/        # Public home page
 ├── packages/               # Shared packages (ALWAYS use these!)
 │   ├── ui/                # Aggregated UI library with Storybook
 │   ├── api/               # OpenAPI client + MSW mocks
@@ -23,6 +32,19 @@ nugudi/
 └── turbo.json             # Monorepo task orchestration
 ```
 
+### 🔐 Route Groups: Authentication Structure
+
+Next.js 15 route groups organize pages by authentication requirements:
+
+- **(auth)**: Protected pages requiring user authentication
+  - All pages inside this group require a logged-in user
+  - Examples: `/benefits`, `/my`, user dashboard, etc.
+- **(public)**: Public pages accessible without authentication
+  - All pages inside this group are accessible to everyone
+  - Examples: `/auth/sign-in`, `/auth/sign-up`, `/home`, etc.
+
+**Note**: Route groups (parentheses folders) don't affect the URL structure - they're purely for organization.
+
 ---
 
 ## 🎯 Core Development Rules
@@ -31,13 +53,13 @@ nugudi/
 
 ```typescript
 // ✅ CORRECT - Use packages
-import Button from '@nugudi/react-components-button';
-import { useToggle } from '@nugudi/react-hooks-toggle';
-import { variables } from '@nugudi/themes';
-import { Icons } from '@nugudi/assets-icons';
+import Button from "@nugudi/react-components-button";
+import { useToggle } from "@nugudi/react-hooks-toggle";
+import { variables } from "@nugudi/themes";
+import { Icons } from "@nugudi/assets-icons";
 
 // ❌ WRONG - Don't create new implementations
-import Button from './components/button'; // NO!
+import Button from "./components/button"; // NO!
 ```
 
 ### Package Import Priority
@@ -121,71 +143,140 @@ Co-Authored-By: Claude <noreply@anthropic.com>"  # NO!
 
 ```typescript
 // Individual component imports
-import Button from '@nugudi/react-components-button';
-import Input from '@nugudi/react-components-input';
-import { Box, Flex, VStack, HStack } from '@nugudi/react-components-layout';
-import Chip from '@nugudi/react-components-chip';
-import NavigationItem from '@nugudi/react-components-navigation-item';
-import Switch from '@nugudi/react-components-switch';
-import Tab from '@nugudi/react-components-tab';
-import Textarea from '@nugudi/react-components-textarea';
-import InputOTP from '@nugudi/react-components-input-otp';
-import StepIndicator from '@nugudi/react-components-step-indicator';
-import MenuCard from '@nugudi/react-components-menu-card';
-import BottomSheet from '@nugudi/react-components-bottom-sheet';
-import Backdrop from '@nugudi/react-components-backdrop';
+import Button from "@nugudi/react-components-button";
+import Input from "@nugudi/react-components-input";
+import { Box, Flex, VStack, HStack } from "@nugudi/react-components-layout";
+import Chip from "@nugudi/react-components-chip";
+import { NavigationItem } from "@nugudi/react-components-navigation-item"; // Named export
+import Switch from "@nugudi/react-components-switch";
+import Tab from "@nugudi/react-components-tab";
+import Textarea from "@nugudi/react-components-textarea";
+import InputOTP from "@nugudi/react-components-input-otp";
+import StepIndicator from "@nugudi/react-components-step-indicator";
+import MenuCard from "@nugudi/react-components-menu-card";
+import BottomSheet from "@nugudi/react-components-bottom-sheet";
+import Backdrop from "@nugudi/react-components-backdrop";
+
+// NavigationItem usage example
+<NavigationItem
+  leftIcon={<CoinIcon />}
+  rightIcon={<ArrowRightIcon />}
+  onClick={() => console.log("clicked")}
+>
+  <div>Content with title and description</div>
+</NavigationItem>;
 ```
 
 ### React Hooks (`@nugudi/react-hooks-*`)
 
 ```typescript
 // Individual hook imports
-import { useButton, useToggleButton } from '@nugudi/react-hooks-button';
-import { useSwitch, useToggleSwitch } from '@nugudi/react-hooks-switch';
-import { useToggle } from '@nugudi/react-hooks-toggle';
-import { useStepper } from '@nugudi/react-hooks-use-stepper';
+import { useButton, useToggleButton } from "@nugudi/react-hooks-button";
+import { useSwitch, useToggleSwitch } from "@nugudi/react-hooks-switch";
+import { useToggle } from "@nugudi/react-hooks-toggle";
+import { useStepper } from "@nugudi/react-hooks-use-stepper";
 ```
 
 ### API Client (`@nugudi/api`)
 
 ```typescript
 // Use auto-generated API client from OpenAPI spec
-import { api } from '@nugudi/api';
-import { useQuery } from '@tanstack/react-query';
+import { api } from "@nugudi/api";
+import { useQuery } from "@tanstack/react-query";
 
 // API hooks with TanStack Query
 export function useUserProfile(userId: string) {
   return useQuery({
-    queryKey: ['user', userId],
+    queryKey: ["user", userId],
     queryFn: () => api.users.getProfile(userId),
   });
 }
 
 // MSW mocks available for testing
-import { handlers } from '@nugudi/api/index.msw';
+import { handlers } from "@nugudi/api/index.msw";
 ```
 
 ### Themes (`@nugudi/themes`)
 
-```typescript
-// Design tokens and theme configuration
-import { variables } from '@nugudi/themes';
-import { classes } from '@nugudi/themes';
+#### Design Foundation Structure
 
-// Use CSS custom properties through Vanilla Extract
-const { colors, typography, box } = variables;
+**vars** - Design tokens available:
+
+```typescript
+// Colors
+vars.colors.$static       // Static colors
+vars.colors.$scale        // Color scales
+  - whiteAlpha[100, 200, 300, 400, 500, 600, 700, 800, 900]
+  - blackAlpha[100, 200, 300, 400, 500, 600, 700, 800, 900]
+  - gray[50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]
+  - red, yellow, green, blue, etc. (same scale)
+
+// Spacing
+vars.box.spacing[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64]
+
+// Border Radius
+vars.box.radii
+  - none, sm, md, lg, xl, 2xl, 3xl, full
+
+// Shadows
+vars.box.shadows
+  - xs, sm, md, lg, xl, 2xl, inner
+
+// Typography
+vars.typography.fontSize
+vars.typography.fontWeight
+vars.typography.lineHeight
+```
+
+**classes** - Pre-defined utility classes:
+
+```typescript
+// Common classes available
+classes.container;
+classes.flexCenter;
+classes.stack;
+// Check the actual theme package for full list
+```
+
+#### Usage Example
+
+```typescript
+import { vars, classes } from "@nugudi/themes";
+import { style } from "@vanilla-extract/css";
+
+// Use pre-defined classes when available
+export const container = classes.container;
+
+// Use design tokens for custom styles
+export const customCard = style({
+  backgroundColor: vars.colors.$scale.whiteAlpha[100],
+  borderRadius: vars.box.radii.lg,
+  padding: vars.box.spacing[16],
+  boxShadow: vars.box.shadows.sm,
+});
 ```
 
 ### Assets (`@nugudi/assets-icons`)
 
 ```typescript
-// Icon components
-import { Icons } from '@nugudi/assets-icons';
+// Icon components - Import individual icons directly
+import { AppleIcon, HeartIcon, CalendarIcon } from '@nugudi/assets-icons';
+import { ChevronRightIcon, ArrowRightIcon } from '@nugudi/assets-icons';
+import { CoinIcon } from '@nugudi/assets-icons';
 
-// Use icons
-<Icons.Apple />
-<Icons.Heart />
-<Icons.Calendar />
+// Use icons as components
+<AppleIcon />
+<HeartIcon />
+<CalendarIcon />
+<ChevronRightIcon />
+
+// Example usage in NavigationItem
+<NavigationItem
+  leftIcon={<CoinIcon />}
+  rightIcon={<ArrowRightIcon />}
+>
+  Content
+</NavigationItem>
 ```
 
 ---
@@ -197,27 +288,33 @@ import { Icons } from '@nugudi/assets-icons';
 ```
 apps/web/
 ├── app/                    # Next.js App Router
-│   ├── auth/              # Auth routes
-│   │   ├── sign-in/       # Sign in pages
-│   │   ├── sign-up/       # Sign up pages
-│   │   └── my/            # User profile
-│   ├── benefits/          # Benefits page
-│   └── layout.tsx         # Root layout
+│   ├── (auth)/            # Protected routes
+│   │   ├── benefits/
+│   │   └── my/
+│   └── (public)/          # Public routes
+│       └── auth/
+│           ├── sign-in/
+│           └── sign-up/
 ├── src/
 │   ├── domains/           # Domain logic
-│   │   └── auth/          # Authentication domain
-│   │       ├── sign-in/
-│   │       ├── sign-up/
-│   │       ├── my/
-│   │       └── password-forgot/
-│   │           ├── constants/
-│   │           ├── schemas/
-│   │           ├── stores/
-│   │           ├── types/
-│   │           └── ui/
-│   │               ├── components/
-│   │               ├── sections/
-│   │               └── views/
+│   │   ├── auth/          # Complex domain with multiple features
+│   │   │   ├── sign-in/
+│   │   │   ├── sign-up/
+│   │   │   ├── my/
+│   │   │   └── password-forgot/
+│   │   │       ├── constants/
+│   │   │       ├── schemas/
+│   │   │       ├── stores/
+│   │   │       ├── types/
+│   │   │       └── ui/
+│   │   │           ├── components/
+│   │   │           ├── sections/
+│   │   │           └── views/
+│   │   └── benefit/       # Simple domain without sub-features
+│   │       └── ui/        # UI directly under domain
+│   │           ├── components/
+│   │           ├── sections/
+│   │           └── views/
 │   └── shared/            # Shared utilities
 │       ├── configs/       # Configuration
 │       ├── providers/     # React providers
@@ -259,12 +356,12 @@ export const SignUpForm: React.FC<SignUpFormProps> = (props) => {
 };
 
 // src/domains/auth/sign-up/ui/components/sign-up-form/index.css.ts
-import { style } from '@vanilla-extract/css';
-import { variables } from '@nugudi/themes';
+import { style } from "@vanilla-extract/css";
+import { variables } from "@nugudi/themes";
 
 export const formContainer = style({
-  display: 'flex',
-  flexDirection: 'column',
+  display: "flex",
+  flexDirection: "column",
   gap: variables.box.spacing.md,
 });
 ```
@@ -289,24 +386,49 @@ export const useSignUpStore = create<SignUpStore>((set) => ({
 
 ## 🎨 Styling Guidelines
 
+### 🚨 CRITICAL: Style Priority Rules
+
+**YOU MUST check and use existing styles in this EXACT order:**
+
+1. **FIRST - Check `classes`**: Always check if a pre-defined class exists
+   - `classes.container`, `classes.flexCenter`, etc.
+2. **SECOND - Use `vars`**: Use design tokens for all style properties
+   - Colors: `vars.colors.$scale.gray[500]` NOT `#6B7280`
+   - Spacing: `vars.box.spacing[16]` NOT `16px`
+   - Radius: `vars.box.radii.lg` NOT `12px`
+   - Shadows: `vars.box.shadows.sm` NOT custom shadows
+3. **LAST - Custom values**: Only for specific requirements
+   - Specific widths/heights: `width: "149px"` (when design requires exact size)
+
+**❌ NEVER use hard-coded values when vars exist!**
+
 ### Vanilla Extract Usage
 
 ```typescript
-// ✅ CORRECT - Use Vanilla Extract for component styles
-// style.css.ts
-import { style } from '@vanilla-extract/css';
-import { variables } from '@nugudi/themes';
+// ✅ CORRECT - Always prioritize existing theme values
+// index.css.ts
+import { style } from "@vanilla-extract/css";
+import { vars, classes } from "@nugudi/themes";
 
-export const button = style({
-  padding: variables.box.spacing.md,
-  borderRadius: variables.box.radii.md,
-  backgroundColor: variables.colors.primary,
+// FIRST: Check if there's a pre-defined class
+export const container = classes.container; // If exists
+
+// SECOND: Use design tokens from vars
+export const customCard = style({
+  // Always use vars for consistent design
+  padding: vars.box.spacing[16], // NOT: padding: '16px'
+  borderRadius: vars.box.radii.lg, // NOT: borderRadius: '12px'
+  backgroundColor: vars.colors.$scale.whiteAlpha[100], // NOT: backgroundColor: 'white'
+  boxShadow: vars.box.shadows.sm, // NOT: boxShadow: '0 1px 3px rgba(0,0,0,0.1)'
+
+  // Only use custom values when absolutely necessary
+  width: "149px", // OK if specific requirement
 });
 
 // Component file
-import * as styles from './style.css';
+import * as styles from "./index.css";
 
-<button className={styles.button}>Click me</button>
+<div className={styles.customCard}>Content</div>;
 ```
 
 ### CSS Modules for App-specific Styles
@@ -328,14 +450,14 @@ import * as styles from './style.css';
 
 ```typescript
 // Use @nugudi/api for all backend communication
-import { api } from '@nugudi/api';
+import { api } from "@nugudi/api";
 
 // TanStack Query for data fetching
-import { useQuery } from '@tanstack/react-query';
+import { useQuery } from "@tanstack/react-query";
 
 export function useMenuData(date: string) {
   return useQuery({
-    queryKey: ['menu', date],
+    queryKey: ["menu", date],
     queryFn: () => api.menu.getByDate(date),
   });
 }
@@ -344,15 +466,15 @@ export function useMenuData(date: string) {
 ### Form Handling with React Hook Form
 
 ```typescript
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { signUpSchema } from '../schemas/sign-up-schema';
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { signUpSchema } from "../schemas/sign-up-schema";
 
 const form = useForm({
   resolver: zodResolver(signUpSchema),
   defaultValues: {
-    email: '',
-    password: '',
+    email: "",
+    password: "",
   },
 });
 ```
@@ -555,21 +677,21 @@ pnpm storybook --filter=ui
 
 ```typescript
 // Component usage
-import Button from '@nugudi/react-components-button';
-import { Box, Flex } from '@nugudi/react-components-layout';
+import Button from "@nugudi/react-components-button";
+import { Box, Flex } from "@nugudi/react-components-layout";
 
 // Hook usage
-import { useToggle } from '@nugudi/react-hooks-toggle';
-import { useStepper } from '@nugudi/react-hooks-use-stepper';
+import { useToggle } from "@nugudi/react-hooks-toggle";
+import { useStepper } from "@nugudi/react-hooks-use-stepper";
 
 // API usage
-import { api } from '@nugudi/api';
+import { api } from "@nugudi/api";
 
 // Theme usage
-import { variables } from '@nugudi/themes';
+import { variables } from "@nugudi/themes";
 
-// Icon usage
-import { Icons } from '@nugudi/assets-icons';
+// Icon usage - Import individual icons
+import { AppleIcon, HeartIcon, ArrowRightIcon } from "@nugudi/assets-icons";
 ```
 
 ---
@@ -613,19 +735,19 @@ pnpm commit                 # Commit with commitizen
 ```typescript
 // ✅ CORRECT - Within same domain (e.g., auth/sign-up)
 // From: src/domains/auth/sign-up/ui/views/sign-up-view/index.tsx
-import { SignUpForm } from '../../components/sign-up-form';
-import { useSignUpStore } from '../../../stores/use-sign-up-store';
-import { signUpSchema } from '../../../schemas/sign-up-schema';
-import type { SignUpFormData } from '../../../types/sign-up';
+import { SignUpForm } from "../../components/sign-up-form";
+import { useSignUpStore } from "../../../stores/use-sign-up-store";
+import { signUpSchema } from "../../../schemas/sign-up-schema";
+import type { SignUpFormData } from "../../../types/sign-up";
 
 // ✅ CORRECT - From section to component in same domain
 // From: src/domains/auth/sign-up/ui/sections/sign-up-section/index.tsx
-import { EmailForm } from '../../components/sign-up-form/steps/email-form';
-import { PasswordForm } from '../../components/sign-up-form/steps/password-form';
+import { EmailForm } from "../../components/sign-up-form/steps/email-form";
+import { PasswordForm } from "../../components/sign-up-form/steps/password-form";
 
 // ✅ CORRECT - Within same folder
 // From: src/domains/auth/sign-up/ui/components/sign-up-form/steps/email-form/index.tsx
-import * as styles from './index.css';
+import * as styles from "./index.css";
 ```
 
 #### Cross-Domain or from App - Use Absolute Imports
@@ -633,22 +755,26 @@ import * as styles from './index.css';
 ```typescript
 // ✅ CORRECT - Cross-domain imports
 // From: src/domains/menu/...
-import { useAuth } from '@/domains/auth/hooks/use-auth';
+import { useAuth } from "@/domains/auth/hooks/use-auth";
 
-// ✅ CORRECT - From app pages
-// From: app/auth/sign-up/page.tsx
-import { SignUpView } from '@/domains/auth/sign-up/ui/views/sign-up-view';
+// ✅ CORRECT - From app pages (public routes)
+// From: app/(public)/auth/sign-up/page.tsx
+import { SignUpView } from "@/domains/auth/sign-up/ui/views/sign-up-view";
+
+// ✅ CORRECT - From app pages (protected routes)
+// From: app/(auth)/benefits/page.tsx
+import { BenefitPageView } from "@/domains/benefit/ui/views/benefit-page-view";
 ```
 
 #### Package Imports - Always Use Package Path
 
 ```typescript
 // ✅ CORRECT - Always use package imports for packages
-import Button from '@nugudi/react-components-button';
-import { variables } from '@nugudi/themes';
+import Button from "@nugudi/react-components-button";
+import { variables } from "@nugudi/themes";
 
 // ❌ WRONG - Never use relative imports for packages
-import Button from '../../../../../packages/react/components/button'; // NO!
+import Button from "../../../../../packages/react/components/button"; // NO!
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 
 #### When Working with Next.js Components:
 
-- **IF** creating or modifying pages in `app/` or components in `src/domains/*/ui/`
+- **IF** creating or modifying pages in `app/(auth)/` or `app/(public)/` or components in `src/domains/*/ui/`
 - **THEN** read [claude/nextjs-component-structure-guideline.md](./claude/nextjs-component-structure-guideline.md) — Next.js App Router component hierarchy (Page → View → Section → Component)
 
 ## ⚠️ CRITICAL REMINDERS

--- a/claude/packages.md
+++ b/claude/packages.md
@@ -12,6 +12,15 @@ This is a **Turbo-powered pnpm workspace monorepo** with a **Design System-first
 nugudi/
 ├── apps/                    # Applications
 │   └── web/                # Next.js 15 + React 19 (Main Web App)
+│       └── app/           # Next.js App Router
+│           ├── (auth)/    # 🔒 Protected routes - Require authentication
+│           │   ├── benefits/     # Benefits page (authenticated users only)
+│           │   └── my/          # My page/profile (authenticated users only)
+│           └── (public)/  # 🌍 Public routes - No authentication required
+│               ├── auth/        # Auth-related public pages
+│               │   ├── sign-in/ # Sign in page
+│               │   └── sign-up/ # Sign up page
+│               └── home/        # Public home page
 ├── packages/               # Shared packages (ALWAYS use these!)
 │   ├── ui/                # Aggregated UI library with Storybook
 │   ├── api/               # OpenAPI client + MSW mocks
@@ -23,6 +32,19 @@ nugudi/
 └── turbo.json             # Monorepo task orchestration
 ```
 
+### 🔐 Route Groups: Authentication Structure
+
+Next.js 15 route groups organize pages by authentication requirements:
+
+- **(auth)**: Protected pages requiring user authentication
+  - All pages inside this group require a logged-in user
+  - Examples: `/benefits`, `/my`, user dashboard, etc.
+- **(public)**: Public pages accessible without authentication
+  - All pages inside this group are accessible to everyone
+  - Examples: `/auth/sign-in`, `/auth/sign-up`, `/home`, etc.
+
+**Note**: Route groups (parentheses folders) don't affect the URL structure - they're purely for organization.
+
 ---
 
 ## 🎯 Core Development Rules
@@ -31,13 +53,13 @@ nugudi/
 
 ```typescript
 // ✅ CORRECT - Use packages
-import Button from '@nugudi/react-components-button';
-import { useToggle } from '@nugudi/react-hooks-toggle';
-import { variables } from '@nugudi/themes';
-import { Icons } from '@nugudi/assets-icons';
+import Button from "@nugudi/react-components-button";
+import { useToggle } from "@nugudi/react-hooks-toggle";
+import { variables } from "@nugudi/themes";
+import { Icons } from "@nugudi/assets-icons";
 
 // ❌ WRONG - Don't create new implementations
-import Button from './components/button'; // NO!
+import Button from "./components/button"; // NO!
 ```
 
 ### Package Import Priority
@@ -121,71 +143,140 @@ Co-Authored-By: Claude <noreply@anthropic.com>"  # NO!
 
 ```typescript
 // Individual component imports
-import Button from '@nugudi/react-components-button';
-import Input from '@nugudi/react-components-input';
-import { Box, Flex, VStack, HStack } from '@nugudi/react-components-layout';
-import Chip from '@nugudi/react-components-chip';
-import NavigationItem from '@nugudi/react-components-navigation-item';
-import Switch from '@nugudi/react-components-switch';
-import Tab from '@nugudi/react-components-tab';
-import Textarea from '@nugudi/react-components-textarea';
-import InputOTP from '@nugudi/react-components-input-otp';
-import StepIndicator from '@nugudi/react-components-step-indicator';
-import MenuCard from '@nugudi/react-components-menu-card';
-import BottomSheet from '@nugudi/react-components-bottom-sheet';
-import Backdrop from '@nugudi/react-components-backdrop';
+import Button from "@nugudi/react-components-button";
+import Input from "@nugudi/react-components-input";
+import { Box, Flex, VStack, HStack } from "@nugudi/react-components-layout";
+import Chip from "@nugudi/react-components-chip";
+import { NavigationItem } from "@nugudi/react-components-navigation-item"; // Named export
+import Switch from "@nugudi/react-components-switch";
+import Tab from "@nugudi/react-components-tab";
+import Textarea from "@nugudi/react-components-textarea";
+import InputOTP from "@nugudi/react-components-input-otp";
+import StepIndicator from "@nugudi/react-components-step-indicator";
+import MenuCard from "@nugudi/react-components-menu-card";
+import BottomSheet from "@nugudi/react-components-bottom-sheet";
+import Backdrop from "@nugudi/react-components-backdrop";
+
+// NavigationItem usage example
+<NavigationItem
+  leftIcon={<CoinIcon />}
+  rightIcon={<ArrowRightIcon />}
+  onClick={() => console.log("clicked")}
+>
+  <div>Content with title and description</div>
+</NavigationItem>;
 ```
 
 ### React Hooks (`@nugudi/react-hooks-*`)
 
 ```typescript
 // Individual hook imports
-import { useButton, useToggleButton } from '@nugudi/react-hooks-button';
-import { useSwitch, useToggleSwitch } from '@nugudi/react-hooks-switch';
-import { useToggle } from '@nugudi/react-hooks-toggle';
-import { useStepper } from '@nugudi/react-hooks-use-stepper';
+import { useButton, useToggleButton } from "@nugudi/react-hooks-button";
+import { useSwitch, useToggleSwitch } from "@nugudi/react-hooks-switch";
+import { useToggle } from "@nugudi/react-hooks-toggle";
+import { useStepper } from "@nugudi/react-hooks-use-stepper";
 ```
 
 ### API Client (`@nugudi/api`)
 
 ```typescript
 // Use auto-generated API client from OpenAPI spec
-import { api } from '@nugudi/api';
-import { useQuery } from '@tanstack/react-query';
+import { api } from "@nugudi/api";
+import { useQuery } from "@tanstack/react-query";
 
 // API hooks with TanStack Query
 export function useUserProfile(userId: string) {
   return useQuery({
-    queryKey: ['user', userId],
+    queryKey: ["user", userId],
     queryFn: () => api.users.getProfile(userId),
   });
 }
 
 // MSW mocks available for testing
-import { handlers } from '@nugudi/api/index.msw';
+import { handlers } from "@nugudi/api/index.msw";
 ```
 
 ### Themes (`@nugudi/themes`)
 
-```typescript
-// Design tokens and theme configuration
-import { variables } from '@nugudi/themes';
-import { classes } from '@nugudi/themes';
+#### Design Foundation Structure
 
-// Use CSS custom properties through Vanilla Extract
-const { colors, typography, box } = variables;
+**vars** - Design tokens available:
+
+```typescript
+// Colors
+vars.colors.$static       // Static colors
+vars.colors.$scale        // Color scales
+  - whiteAlpha[100, 200, 300, 400, 500, 600, 700, 800, 900]
+  - blackAlpha[100, 200, 300, 400, 500, 600, 700, 800, 900]
+  - gray[50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]
+  - red, yellow, green, blue, etc. (same scale)
+
+// Spacing
+vars.box.spacing[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64]
+
+// Border Radius
+vars.box.radii
+  - none, sm, md, lg, xl, 2xl, 3xl, full
+
+// Shadows
+vars.box.shadows
+  - xs, sm, md, lg, xl, 2xl, inner
+
+// Typography
+vars.typography.fontSize
+vars.typography.fontWeight
+vars.typography.lineHeight
+```
+
+**classes** - Pre-defined utility classes:
+
+```typescript
+// Common classes available
+classes.container;
+classes.flexCenter;
+classes.stack;
+// Check the actual theme package for full list
+```
+
+#### Usage Example
+
+```typescript
+import { vars, classes } from "@nugudi/themes";
+import { style } from "@vanilla-extract/css";
+
+// Use pre-defined classes when available
+export const container = classes.container;
+
+// Use design tokens for custom styles
+export const customCard = style({
+  backgroundColor: vars.colors.$scale.whiteAlpha[100],
+  borderRadius: vars.box.radii.lg,
+  padding: vars.box.spacing[16],
+  boxShadow: vars.box.shadows.sm,
+});
 ```
 
 ### Assets (`@nugudi/assets-icons`)
 
 ```typescript
-// Icon components
-import { Icons } from '@nugudi/assets-icons';
+// Icon components - Import individual icons directly
+import { AppleIcon, HeartIcon, CalendarIcon } from '@nugudi/assets-icons';
+import { ChevronRightIcon, ArrowRightIcon } from '@nugudi/assets-icons';
+import { CoinIcon } from '@nugudi/assets-icons';
 
-// Use icons
-<Icons.Apple />
-<Icons.Heart />
-<Icons.Calendar />
+// Use icons as components
+<AppleIcon />
+<HeartIcon />
+<CalendarIcon />
+<ChevronRightIcon />
+
+// Example usage in NavigationItem
+<NavigationItem
+  leftIcon={<CoinIcon />}
+  rightIcon={<ArrowRightIcon />}
+>
+  Content
+</NavigationItem>
 ```
 
 ---
@@ -197,27 +288,33 @@ import { Icons } from '@nugudi/assets-icons';
 ```
 apps/web/
 ├── app/                    # Next.js App Router
-│   ├── auth/              # Auth routes
-│   │   ├── sign-in/       # Sign in pages
-│   │   ├── sign-up/       # Sign up pages
-│   │   └── my/            # User profile
-│   ├── benefits/          # Benefits page
-│   └── layout.tsx         # Root layout
+│   ├── (auth)/            # Protected routes
+│   │   ├── benefits/
+│   │   └── my/
+│   └── (public)/          # Public routes
+│       └── auth/
+│           ├── sign-in/
+│           └── sign-up/
 ├── src/
 │   ├── domains/           # Domain logic
-│   │   └── auth/          # Authentication domain
-│   │       ├── sign-in/
-│   │       ├── sign-up/
-│   │       ├── my/
-│   │       └── password-forgot/
-│   │           ├── constants/
-│   │           ├── schemas/
-│   │           ├── stores/
-│   │           ├── types/
-│   │           └── ui/
-│   │               ├── components/
-│   │               ├── sections/
-│   │               └── views/
+│   │   ├── auth/          # Complex domain with multiple features
+│   │   │   ├── sign-in/
+│   │   │   ├── sign-up/
+│   │   │   ├── my/
+│   │   │   └── password-forgot/
+│   │   │       ├── constants/
+│   │   │       ├── schemas/
+│   │   │       ├── stores/
+│   │   │       ├── types/
+│   │   │       └── ui/
+│   │   │           ├── components/
+│   │   │           ├── sections/
+│   │   │           └── views/
+│   │   └── benefit/       # Simple domain without sub-features
+│   │       └── ui/        # UI directly under domain
+│   │           ├── components/
+│   │           ├── sections/
+│   │           └── views/
 │   └── shared/            # Shared utilities
 │       ├── configs/       # Configuration
 │       ├── providers/     # React providers
@@ -259,12 +356,12 @@ export const SignUpForm: React.FC<SignUpFormProps> = (props) => {
 };
 
 // src/domains/auth/sign-up/ui/components/sign-up-form/index.css.ts
-import { style } from '@vanilla-extract/css';
-import { variables } from '@nugudi/themes';
+import { style } from "@vanilla-extract/css";
+import { variables } from "@nugudi/themes";
 
 export const formContainer = style({
-  display: 'flex',
-  flexDirection: 'column',
+  display: "flex",
+  flexDirection: "column",
   gap: variables.box.spacing.md,
 });
 ```
@@ -289,24 +386,49 @@ export const useSignUpStore = create<SignUpStore>((set) => ({
 
 ## 🎨 Styling Guidelines
 
+### 🚨 CRITICAL: Style Priority Rules
+
+**YOU MUST check and use existing styles in this EXACT order:**
+
+1. **FIRST - Check `classes`**: Always check if a pre-defined class exists
+   - `classes.container`, `classes.flexCenter`, etc.
+2. **SECOND - Use `vars`**: Use design tokens for all style properties
+   - Colors: `vars.colors.$scale.gray[500]` NOT `#6B7280`
+   - Spacing: `vars.box.spacing[16]` NOT `16px`
+   - Radius: `vars.box.radii.lg` NOT `12px`
+   - Shadows: `vars.box.shadows.sm` NOT custom shadows
+3. **LAST - Custom values**: Only for specific requirements
+   - Specific widths/heights: `width: "149px"` (when design requires exact size)
+
+**❌ NEVER use hard-coded values when vars exist!**
+
 ### Vanilla Extract Usage
 
 ```typescript
-// ✅ CORRECT - Use Vanilla Extract for component styles
-// style.css.ts
-import { style } from '@vanilla-extract/css';
-import { variables } from '@nugudi/themes';
+// ✅ CORRECT - Always prioritize existing theme values
+// index.css.ts
+import { style } from "@vanilla-extract/css";
+import { vars, classes } from "@nugudi/themes";
 
-export const button = style({
-  padding: variables.box.spacing.md,
-  borderRadius: variables.box.radii.md,
-  backgroundColor: variables.colors.primary,
+// FIRST: Check if there's a pre-defined class
+export const container = classes.container; // If exists
+
+// SECOND: Use design tokens from vars
+export const customCard = style({
+  // Always use vars for consistent design
+  padding: vars.box.spacing[16], // NOT: padding: '16px'
+  borderRadius: vars.box.radii.lg, // NOT: borderRadius: '12px'
+  backgroundColor: vars.colors.$scale.whiteAlpha[100], // NOT: backgroundColor: 'white'
+  boxShadow: vars.box.shadows.sm, // NOT: boxShadow: '0 1px 3px rgba(0,0,0,0.1)'
+
+  // Only use custom values when absolutely necessary
+  width: "149px", // OK if specific requirement
 });
 
 // Component file
-import * as styles from './style.css';
+import * as styles from "./index.css";
 
-<button className={styles.button}>Click me</button>
+<div className={styles.customCard}>Content</div>;
 ```
 
 ### CSS Modules for App-specific Styles
@@ -328,14 +450,14 @@ import * as styles from './style.css';
 
 ```typescript
 // Use @nugudi/api for all backend communication
-import { api } from '@nugudi/api';
+import { api } from "@nugudi/api";
 
 // TanStack Query for data fetching
-import { useQuery } from '@tanstack/react-query';
+import { useQuery } from "@tanstack/react-query";
 
 export function useMenuData(date: string) {
   return useQuery({
-    queryKey: ['menu', date],
+    queryKey: ["menu", date],
     queryFn: () => api.menu.getByDate(date),
   });
 }
@@ -344,15 +466,15 @@ export function useMenuData(date: string) {
 ### Form Handling with React Hook Form
 
 ```typescript
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { signUpSchema } from '../schemas/sign-up-schema';
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { signUpSchema } from "../schemas/sign-up-schema";
 
 const form = useForm({
   resolver: zodResolver(signUpSchema),
   defaultValues: {
-    email: '',
-    password: '',
+    email: "",
+    password: "",
   },
 });
 ```
@@ -555,21 +677,21 @@ pnpm storybook --filter=ui
 
 ```typescript
 // Component usage
-import Button from '@nugudi/react-components-button';
-import { Box, Flex } from '@nugudi/react-components-layout';
+import Button from "@nugudi/react-components-button";
+import { Box, Flex } from "@nugudi/react-components-layout";
 
 // Hook usage
-import { useToggle } from '@nugudi/react-hooks-toggle';
-import { useStepper } from '@nugudi/react-hooks-use-stepper';
+import { useToggle } from "@nugudi/react-hooks-toggle";
+import { useStepper } from "@nugudi/react-hooks-use-stepper";
 
 // API usage
-import { api } from '@nugudi/api';
+import { api } from "@nugudi/api";
 
 // Theme usage
-import { variables } from '@nugudi/themes';
+import { variables } from "@nugudi/themes";
 
-// Icon usage
-import { Icons } from '@nugudi/assets-icons';
+// Icon usage - Import individual icons
+import { AppleIcon, HeartIcon, ArrowRightIcon } from "@nugudi/assets-icons";
 ```
 
 ---
@@ -613,19 +735,19 @@ pnpm commit                 # Commit with commitizen
 ```typescript
 // ✅ CORRECT - Within same domain (e.g., auth/sign-up)
 // From: src/domains/auth/sign-up/ui/views/sign-up-view/index.tsx
-import { SignUpForm } from '../../components/sign-up-form';
-import { useSignUpStore } from '../../../stores/use-sign-up-store';
-import { signUpSchema } from '../../../schemas/sign-up-schema';
-import type { SignUpFormData } from '../../../types/sign-up';
+import { SignUpForm } from "../../components/sign-up-form";
+import { useSignUpStore } from "../../../stores/use-sign-up-store";
+import { signUpSchema } from "../../../schemas/sign-up-schema";
+import type { SignUpFormData } from "../../../types/sign-up";
 
 // ✅ CORRECT - From section to component in same domain
 // From: src/domains/auth/sign-up/ui/sections/sign-up-section/index.tsx
-import { EmailForm } from '../../components/sign-up-form/steps/email-form';
-import { PasswordForm } from '../../components/sign-up-form/steps/password-form';
+import { EmailForm } from "../../components/sign-up-form/steps/email-form";
+import { PasswordForm } from "../../components/sign-up-form/steps/password-form";
 
 // ✅ CORRECT - Within same folder
 // From: src/domains/auth/sign-up/ui/components/sign-up-form/steps/email-form/index.tsx
-import * as styles from './index.css';
+import * as styles from "./index.css";
 ```
 
 #### Cross-Domain or from App - Use Absolute Imports
@@ -633,22 +755,26 @@ import * as styles from './index.css';
 ```typescript
 // ✅ CORRECT - Cross-domain imports
 // From: src/domains/menu/...
-import { useAuth } from '@/domains/auth/hooks/use-auth';
+import { useAuth } from "@/domains/auth/hooks/use-auth";
 
-// ✅ CORRECT - From app pages
-// From: app/auth/sign-up/page.tsx
-import { SignUpView } from '@/domains/auth/sign-up/ui/views/sign-up-view';
+// ✅ CORRECT - From app pages (public routes)
+// From: app/(public)/auth/sign-up/page.tsx
+import { SignUpView } from "@/domains/auth/sign-up/ui/views/sign-up-view";
+
+// ✅ CORRECT - From app pages (protected routes)
+// From: app/(auth)/benefits/page.tsx
+import { BenefitPageView } from "@/domains/benefit/ui/views/benefit-page-view";
 ```
 
 #### Package Imports - Always Use Package Path
 
 ```typescript
 // ✅ CORRECT - Always use package imports for packages
-import Button from '@nugudi/react-components-button';
-import { variables } from '@nugudi/themes';
+import Button from "@nugudi/react-components-button";
+import { variables } from "@nugudi/themes";
 
 // ❌ WRONG - Never use relative imports for packages
-import Button from '../../../../../packages/react/components/button'; // NO!
+import Button from "../../../../../packages/react/components/button"; // NO!
 ```
 
 ---

--- a/packages/themes/src/utils/colors.ts
+++ b/packages/themes/src/utils/colors.ts
@@ -1,0 +1,40 @@
+import { COLOR_SHADES, type ColorShade } from "../constants/color";
+
+export type ColorPalette = Record<ColorShade, string>;
+export type StaticColorPalette = Record<ColorShade, string>;
+
+/**
+ * 색상 팔레트 생성 유틸리티
+ * CSS 변수명을 자동으로 생성하여 색상 스케일 객체 반환
+ * @param colorName - CSS 변수 이름에 사용될 색상명
+ * @returns CSS 변수 형태의 색상 팔레트
+ * @example createColorScale("blue") // { 50: "var(--blue-50)", ... }
+ */
+export const createColorScale = (colorName: string): ColorPalette => {
+  return COLOR_SHADES.reduce(
+    (acc, shade) => {
+      acc[shade] = `var(--${colorName}-${shade})`;
+      return acc;
+    },
+    {} as Record<ColorShade, string>,
+  );
+};
+
+/**
+ * 색상 팔레트의 순서를 반전시킵니다.
+ * 다크 모드에서 사용: 50 ↔ 900, 100 ↔ 800, ... 형태로 변환
+ * @param palette - 반전시킬 색상 팔레트
+ * @returns 순서가 반전된 색상 팔레트
+ * @example reversePalette({ 50: "#fff", ..., 900: "#000" }) // { 50: "#000", ..., 900: "#fff" }
+ */
+export const reversePalette = (
+  palette: StaticColorPalette,
+): StaticColorPalette => {
+  const shades = [...COLOR_SHADES];
+  const reversedShades = [...shades].reverse();
+
+  return shades.reduce((acc, shade, index) => {
+    acc[shade] = palette[reversedShades[index]];
+    return acc;
+  }, {} as StaticColorPalette);
+};

--- a/packages/themes/src/variables/colors/scale.ts
+++ b/packages/themes/src/variables/colors/scale.ts
@@ -1,51 +1,13 @@
-export const main = {
-  50: "var(--main-50)",
-  100: "var(--main-100)",
-  200: "var(--main-200)",
-  300: "var(--main-300)",
-  400: "var(--main-400)",
-  500: "var(--main-500)",
-  600: "var(--main-600)",
-  700: "var(--main-700)",
-  800: "var(--main-800)",
-  900: "var(--main-900)",
-};
+import { createColorScale } from "../../utils/colors";
 
-export const zinc = {
-  50: "var(--zinc-50)",
-  100: "var(--zinc-100)",
-  200: "var(--zinc-200)",
-  300: "var(--zinc-300)",
-  400: "var(--zinc-400)",
-  500: "var(--zinc-500)",
-  600: "var(--zinc-600)",
-  700: "var(--zinc-700)",
-  800: "var(--zinc-800)",
-  900: "var(--zinc-900)",
-};
+export const main = createColorScale("main");
 
-export const whiteAlpha = {
-  50: "var(--white-alpha-50)",
-  100: "var(--white-alpha-100)",
-  200: "var(--white-alpha-200)",
-  300: "var(--white-alpha-300)",
-  400: "var(--white-alpha-400)",
-  500: "var(--white-alpha-500)",
-  600: "var(--white-alpha-600)",
-  700: "var(--white-alpha-700)",
-  800: "var(--white-alpha-800)",
-  900: "var(--white-alpha-900)",
-};
+export const zinc = createColorScale("zinc");
 
-export const blackAlpha = {
-  50: "var(--black-alpha-50)",
-  100: "var(--black-alpha-100)",
-  200: "var(--black-alpha-200)",
-  300: "var(--black-alpha-300)",
-  400: "var(--black-alpha-400)",
-  500: "var(--black-alpha-500)",
-  600: "var(--black-alpha-600)",
-  700: "var(--black-alpha-700)",
-  800: "var(--black-alpha-800)",
-  900: "var(--black-alpha-900)",
-};
+export const whiteAlpha = createColorScale("white-alpha");
+export const blackAlpha = createColorScale("black-alpha");
+
+export const yellow = createColorScale("yellow");
+export const blue = createColorScale("blue");
+export const purple = createColorScale("purple");
+export const red = createColorScale("red");

--- a/packages/themes/src/variables/colors/static/dark.ts
+++ b/packages/themes/src/variables/colors/static/dark.ts
@@ -1,60 +1,30 @@
+import { reversePalette } from "../../../utils/colors";
+import {
+  blackAlphaPalette,
+  bluePalette,
+  mainPalette,
+  purplePalette,
+  redPalette,
+  whiteAlphaPalette,
+  yellowPalette,
+  zincPalette,
+} from "./palettes";
+
+export const main = reversePalette(mainPalette);
+export const zinc = reversePalette(zincPalette);
+export const yellow = reversePalette(yellowPalette);
+export const blue = reversePalette(bluePalette);
+export const purple = reversePalette(purplePalette);
+export const red = reversePalette(redPalette);
+
+export const whiteAlpha = reversePalette(whiteAlphaPalette);
+export const blackAlpha = reversePalette(blackAlphaPalette);
+
 export const color = {
-  black: "#000000",
+  black: "#121212",
   white: "#FFFFFF",
   red: "#F44336",
-  backdrop: "rgba(0, 0, 0, 0.6)",
-};
-
-export const main = {
-  50: "#E5F7EC",
-  100: "#C8F0DA",
-  200: "#A6E5C3",
-  300: "#6FD59E",
-  400: "#35C076",
-  500: "#00B140",
-  600: "#0B8A3A",
-  700: "#13572F",
-  800: "#176435",
-  900: "#0E4226",
-};
-
-export const zinc = {
-  50: "#272729",
-  100: "#403f46",
-  200: "#51525b",
-  300: "#70717a",
-  400: "#A0A1AA",
-  500: "#d4d3d8",
-  600: "#e4e3e6",
-  700: "#f4f4f4",
-  800: "#fafafa",
-  900: "#ffffff",
-};
-
-export const whiteAlpha = {
-  900: "rgba(255, 255, 255, 0.04)",
-  800: "rgba(255, 255, 255, 0.06)",
-  700: "rgba(255, 255, 255, 0.08)",
-  600: "rgba(255, 255, 255, 0.16)",
-  500: "rgba(255, 255, 255, 0.24)",
-  400: "rgba(255, 255, 255, 0.36)",
-  300: "rgba(255, 255, 255, 0.48)",
-  200: "rgba(255, 255, 255, 0.64)",
-  100: "rgba(255, 255, 255, 0.80)",
-  50: "rgba(255, 255, 255, 0.92)",
-};
-
-export const blackAlpha = {
-  900: "rgba(0, 0, 0, 0.04)",
-  800: "rgba(0, 0, 0, 0.06)",
-  700: "rgba(0, 0, 0, 0.08)",
-  600: "rgba(0, 0, 0, 0.16)",
-  500: "rgba(0, 0, 0, 0.24)",
-  400: "rgba(0, 0, 0, 0.36)",
-  300: "rgba(0, 0, 0, 0.48)",
-  200: "rgba(0, 0, 0, 0.64)",
-  100: "rgba(0, 0, 0, 0.80)",
-  50: "rgba(0, 0, 0, 0.92)",
+  backdrop: "rgba(0, 0, 0, 0.5)",
 };
 
 export const gradient = {

--- a/packages/themes/src/variables/colors/static/light.ts
+++ b/packages/themes/src/variables/colors/static/light.ts
@@ -1,60 +1,28 @@
+import {
+  blackAlphaPalette,
+  bluePalette,
+  mainPalette,
+  purplePalette,
+  redPalette,
+  whiteAlphaPalette,
+  yellowPalette,
+  zincPalette,
+} from "./palettes";
+
+export const main = mainPalette;
+export const zinc = zincPalette;
+export const whiteAlpha = whiteAlphaPalette;
+export const blackAlpha = blackAlphaPalette;
+export const yellow = yellowPalette;
+export const blue = bluePalette;
+export const purple = purplePalette;
+export const red = redPalette;
+
 export const color = {
-  black: "#000000",
+  black: "#121212",
   white: "#FFFFFF",
   red: "#F44336",
-  backdrop: "rgba(0, 0, 0, 0.6)",
-};
-
-export const main = {
-  50: "#00B140",
-  100: "#0B8A3A",
-  200: "#176435",
-  300: "#13572F",
-  400: "#0E4226",
-  500: "#00B140",
-  600: "#0B8A3A",
-  700: "#13572F",
-  800: "#176435",
-  900: "#ffffff",
-};
-
-export const zinc = {
-  50: "#fafafa",
-  100: "#f4f4f4",
-  200: "#e4e3e6",
-  300: "#d4d3d8",
-  400: "#a0a1aa",
-  500: "#70717a",
-  600: "#51525b",
-  700: "#403f46",
-  800: "#272729",
-  900: "#1A1A1D",
-};
-
-export const whiteAlpha = {
-  50: "rgba(255, 255, 255, 0.04)",
-  100: "rgba(255, 255, 255, 0.06)",
-  200: "rgba(255, 255, 255, 0.08)",
-  300: "rgba(255, 255, 255, 0.16)",
-  400: "rgba(255, 255, 255, 0.24)",
-  500: "rgba(255, 255, 255, 0.36)",
-  600: "rgba(255, 255, 255, 0.48)",
-  700: "rgba(255, 255, 255, 0.64)",
-  800: "rgba(255, 255, 255, 0.80)",
-  900: "rgba(255, 255, 255, 0.92)",
-};
-
-export const blackAlpha = {
-  50: "rgba(0, 0, 0, 0.04)",
-  100: "rgba(0, 0, 0, 0.06)",
-  200: "rgba(0, 0, 0, 0.08)",
-  300: "rgba(0, 0, 0, 0.16)",
-  400: "rgba(0, 0, 0, 0.24)",
-  500: "rgba(0, 0, 0, 0.36)",
-  600: "rgba(0, 0, 0, 0.48)",
-  700: "rgba(0, 0, 0, 0.64)",
-  800: "rgba(0, 0, 0, 0.80)",
-  900: "rgba(0, 0, 0, 0.92)",
+  backdrop: "rgba(0, 0, 0, 0.5)",
 };
 
 export const gradient = {

--- a/packages/themes/src/variables/colors/static/palettes.ts
+++ b/packages/themes/src/variables/colors/static/palettes.ts
@@ -1,0 +1,110 @@
+import type { StaticColorPalette } from "../../../utils/colors";
+
+/**
+ * 중앙화된 색상 팔레트 정의
+ * Light 테마 기준으로 정의 (50: 가장 밝음 → 900: 가장 어두움)
+ */
+
+export const mainPalette: StaticColorPalette = {
+  50: "#F0FCF4",
+  100: "#E5F8D5",
+  200: "#C8F0B0",
+  300: "#82DC5E",
+  400: "#3CC24E",
+  500: "#00B140",
+  600: "#0B8A3A",
+  700: "#0E6B2E",
+  800: "#176435",
+  900: "#0E4226",
+};
+
+export const zincPalette: StaticColorPalette = {
+  50: "#fafafa",
+  100: "#f4f4f4",
+  200: "#e4e3e6",
+  300: "#d4d3d8",
+  400: "#a0a1aa",
+  500: "#70717a",
+  600: "#51525b",
+  700: "#403f46",
+  800: "#272729",
+  900: "#1A1A1D",
+};
+
+export const yellowPalette: StaticColorPalette = {
+  50: "#fff7de",
+  100: "#fdefb9",
+  200: "#fbdc65",
+  300: "#e9c647",
+  400: "#d4ab28",
+  500: "#c49725",
+  600: "#9b7821",
+  700: "#755b22",
+  800: "#4f3e1f",
+  900: "#2c2512",
+};
+
+export const bluePalette: StaticColorPalette = {
+  50: "#eff6ff",
+  100: "#e2edfc",
+  200: "#cbdffa",
+  300: "#aacefd",
+  400: "#85b8fd",
+  500: "#5e98fe",
+  600: "#217cf9",
+  700: "#135fcd",
+  800: "#0b4596",
+  900: "#032451",
+};
+
+export const purplePalette: StaticColorPalette = {
+  50: "#f5f3fe",
+  100: "#efeafe",
+  200: "#e1d8ff",
+  300: "#d0c0ff",
+  400: "#b8a1ff",
+  500: "#9f84fb",
+  600: "#8969ea",
+  700: "#6d50cb",
+  800: "#50379b",
+  900: "#332074",
+};
+
+export const redPalette: StaticColorPalette = {
+  50: "#fdf0f0",
+  100: "#fde7e7",
+  200: "#fed4d2",
+  300: "#feb7b3",
+  400: "#fe928d",
+  500: "#fe6600",
+  600: "#fc6a66",
+  700: "#fa342c",
+  800: "#ca1d13",
+  900: "#921708",
+};
+
+export const whiteAlphaPalette: StaticColorPalette = {
+  50: "#ffffff0d",
+  100: "#ffffff17",
+  200: "#ffffff20",
+  300: "#ffffff2e",
+  400: "#ffffff3d",
+  500: "#ffffff60",
+  600: "#ffffff8b",
+  700: "#ffffffb3",
+  800: "#ffffffde",
+  900: "#ffffffea",
+};
+
+export const blackAlphaPalette: StaticColorPalette = {
+  50: "#00000007",
+  100: "#0000000c",
+  200: "#00000010",
+  300: "#00000021",
+  400: "#0000002c",
+  500: "#0000004c",
+  600: "#00000074",
+  700: "#000000a2",
+  800: "#000000d0",
+  900: "#000000e3",
+};

--- a/packages/themes/src/variables/colors/static/palettes.ts
+++ b/packages/themes/src/variables/colors/static/palettes.ts
@@ -76,11 +76,11 @@ export const redPalette: StaticColorPalette = {
   200: "#fed4d2",
   300: "#feb7b3",
   400: "#fe928d",
-  500: "#fe6600",
-  600: "#fc6a66",
-  700: "#fa342c",
-  800: "#ca1d13",
-  900: "#921708",
+  500: "#fc6a66",
+  600: "#fa342c",
+  700: "#ca1d13",
+  800: "#921708",
+  900: "#4a1209",
 };
 
 export const whiteAlphaPalette: StaticColorPalette = {

--- a/packages/ui/src/foundations/color.stories.tsx
+++ b/packages/ui/src/foundations/color.stories.tsx
@@ -1,6 +1,6 @@
 import { Body, Grid, Title, VStack } from "@nugudi/react-components-layout";
 import "@nugudi/react-components-layout/style.css";
-import { COLOR_SHADES, vars } from "@nugudi/themes";
+import { COLOR_SHADES, type ColorShade, vars } from "@nugudi/themes";
 
 const colorGroups = Object.keys(vars.colors.$scale);
 
@@ -91,11 +91,7 @@ export const Color = () => {
   );
 };
 
-const ShadeHeader = ({
-  shades,
-}: {
-  shades: (typeof COLOR_SHADES)[number][];
-}) => (
+const ShadeHeader = ({ shades }: { shades: ColorShade[] }) => (
   <Grid templateColumns="100px repeat(10, 1fr)">
     <div />
     {shades.map((shade) => (

--- a/packages/ui/src/foundations/color.stories.tsx
+++ b/packages/ui/src/foundations/color.stories.tsx
@@ -1,118 +1,114 @@
-import { vars } from "@nugudi/themes";
+import { Body, Grid, Title, VStack } from "@nugudi/react-components-layout";
+import "@nugudi/react-components-layout/style.css";
+import { COLOR_SHADES, vars } from "@nugudi/themes";
 
 const colorGroups = Object.keys(vars.colors.$scale);
-const colorOptions = ["all", ...colorGroups];
+
+const grayColors = ["zinc"];
+const chromaticColors = colorGroups.filter(
+  (color) => !grayColors.includes(color),
+);
 
 export default {
   title: "Foundations/Color",
   parameters: {
-    layout: "centered",
-  },
-  argTypes: {
-    colorGroup: {
-      options: colorOptions,
-      control: "select",
-    },
+    layout: "padded",
   },
 };
 
-export const Color = ({ colorGroup = "main" }: { colorGroup?: string }) => {
-  const groupsToShow = colorGroup === "all" ? colorGroups : [colorGroup];
+export const Color = () => {
+  const shades = [...COLOR_SHADES];
 
-  return (
+  const renderColorRow = (colorName: string) => (
     <div
+      key={colorName}
       style={{
         display: "grid",
-        gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-        gap: "32px",
-        padding: "32px",
+        gridTemplateColumns: "100px repeat(10, 1fr)",
+        gap: "4px",
+        alignItems: "center",
       }}
     >
-      {groupsToShow.map((selectedGroup) => (
-        <div
-          key={selectedGroup}
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "16px",
-            padding: "16px",
-            border: "1px solid #e5e7eb",
-            borderRadius: "8px",
-          }}
-        >
-          <h3
-            style={{
-              margin: 0,
-              fontSize: "16px",
-              fontWeight: "600",
-              color: "#111827",
-              textTransform: "capitalize",
-            }}
-          >
-            {selectedGroup}
-          </h3>
+      <Body fontSize="b3" colorShade={500}>
+        {colorName}
+      </Body>
+
+      {shades.map((shade) => {
+        const cssVar =
+          vars.colors.$scale[colorName as keyof typeof vars.colors.$scale]?.[
+            shade
+          ];
+        return (
           <div
+            key={shade}
             style={{
-              display: "grid",
-              gap: "8px",
+              width: "100%",
+              aspectRatio: "2/1",
+              backgroundColor: cssVar || "#f3f4f6",
+              borderRadius: "4px",
             }}
-          >
-            {Object.entries(
-              vars.colors.$scale[
-                selectedGroup as keyof typeof vars.colors.$scale
-              ],
-            ).map(([shade, cssVar]) => (
-              <div
-                key={shade}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "12px",
-                  padding: "8px",
-                  borderRadius: "4px",
-                  border: "1px solid #f3f4f6",
-                }}
-              >
-                <div
-                  style={{
-                    width: "40px",
-                    height: "40px",
-                    backgroundColor: cssVar,
-                    borderRadius: "4px",
-                    border: "1px solid #e5e7eb",
-                    flexShrink: 0,
-                  }}
-                />
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "2px",
-                  }}
-                >
-                  <span
-                    style={{
-                      fontSize: "12px",
-                      fontWeight: "500",
-                      color: "#374151",
-                    }}
-                  >
-                    {selectedGroup}-{shade}
-                  </span>
-                  <span
-                    style={{
-                      fontSize: "10px",
-                      color: "#6b7280",
-                    }}
-                  >
-                    {cssVar}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
+            title={`${colorName}-${shade}`}
+          />
+        );
+      })}
     </div>
   );
+
+  return (
+    <VStack padding={16} gap={48}>
+      {/* Gray Section */}
+      <VStack gap={2}>
+        <Title fontSize="t1">Gray</Title>
+        <VStack gap={2}>
+          <ShadeHeader shades={shades} />
+        </VStack>
+        <VStack gap={2}>
+          {grayColors
+            .filter(
+              (color) =>
+                vars.colors.$scale[color as keyof typeof vars.colors.$scale],
+            )
+            .map(renderColorRow)}
+        </VStack>
+      </VStack>
+
+      {/* Chromatic Section */}
+      <VStack gap={2}>
+        <Title fontSize="t1">Chromatic</Title>
+        <VStack gap={2}>
+          <ShadeHeader shades={shades} />
+        </VStack>
+        <VStack gap={2}>
+          {chromaticColors
+            .filter(
+              (color) =>
+                vars.colors.$scale[color as keyof typeof vars.colors.$scale],
+            )
+            .map(renderColorRow)}
+        </VStack>
+      </VStack>
+    </VStack>
+  );
 };
+
+const ShadeHeader = ({
+  shades,
+}: {
+  shades: (typeof COLOR_SHADES)[number][];
+}) => (
+  <Grid templateColumns="100px repeat(10, 1fr)">
+    <div />
+    {shades.map((shade) => (
+      <Body
+        fontSize="b4"
+        colorShade={500}
+        key={shade}
+        style={{
+          textAlign: "center",
+        }}
+      >
+        {shade}
+      </Body>
+    ))}
+  </Grid>
+);


### PR DESCRIPTION
## 🌀 Issue Number

<!-- #이슈번호 -->

- #128

## 😵 As-Is

<!-- 문제 상황 정의 -->

- 스토리북에 main 색상만 정의되어 있는 문제
- main과 zinc 색상 이외의 다양한 색상의 부재 

## 🥳 To-Be

<!-- 변경 사항 -->

- 색상 팔레트를 palettes.ts 파일로 중앙화하여 light/dark 테마 간 일관성 확보
- createColorScale, reversePalette 유틸리티 함수 추가로 색상 스케일 생성 자동화
- Storybook 색상 미리보기 UI 개선 (Gray/Chromatic 섹션 분리)
- red, yellow 등 다양한 색상 추가

## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Screenshot (Optional)


<img width="800" height="601" alt="스크린샷 2025-08-27 23 52 11" src="https://github.com/user-attachments/assets/84fceb82-cd68-4381-90ef-e61477d47589" />


<img width="341" height="113" alt="빌드" src="https://github.com/user-attachments/assets/e6083559-b75c-4181-a9c4-de0eaf0bfdfe" />

## 👾 Additional Description (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 새로운 컬러 팔레트(Yellow, Blue, Purple, Red) 추가 및 팔레트 기반 색상 스케일 도입으로 테마 일관성 향상.
- **스타일**
  - 기본 검정색 톤을 #121212로 조정.
  - 백드롭 투명도를 0.6→0.5로 완화하여 가독성 개선.
- **문서화**
  - 스토리북 색상 페이지 개편: Gray/Chromatic 분리, 음영별(50–900) 스와치 뷰어 및 레이아웃 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->