### PR TITLE
[NUGUDI-114] 혜택 페이지 UI 수정

### DIFF
--- a/apps/web/src/domains/auth/my/ui/views/my-page-view/index.tsx
+++ b/apps/web/src/domains/auth/my/ui/views/my-page-view/index.tsx
@@ -1,4 +1,5 @@
 import { Flex } from "@nugudi/react-components-layout";
+import { AppHeader } from "@/src/shared/ui/components/app-header";
 import LogoutButton from "../../components/logout-button";
 import MenuSection from "../../sections/menu-section";
 import PointSection from "../../sections/point-section";
@@ -8,6 +9,7 @@ import * as styles from "./index.css";
 const MyPageView = () => {
   return (
     <Flex direction="column" className={styles.container}>
+      <AppHeader />
       <ProfileSection />
       <PointSection />
       <MenuSection />

--- a/apps/web/src/domains/benefit/ui/components/benefit-card/index.css.ts
+++ b/apps/web/src/domains/benefit/ui/components/benefit-card/index.css.ts
@@ -2,19 +2,36 @@ import { vars } from "@nugudi/themes";
 import { style } from "@vanilla-extract/css";
 
 export const card = style({
-  width: "149px",
   height: "152px",
   backgroundColor: vars.colors.$scale.whiteAlpha[100],
-  borderRadius: vars.box.radii.lg,
+  border: `1px solid ${vars.colors.$scale.zinc[50]}`,
+  borderRadius: "10px",
   padding: vars.box.spacing[16],
-  boxShadow: vars.box.shadows.sm,
   display: "flex",
-  flexDirection: "column",
-  justifyContent: "space-between",
+  position: "relative",
   cursor: "pointer",
   transition: "all 0.2s ease",
   ":hover": {
-    boxShadow: vars.box.shadows.md,
     transform: "translateY(-2px)",
+    boxShadow: vars.box.shadows.sm,
   },
+});
+
+export const contentWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  position: "absolute",
+  textAlign: "left",
+  top: 20,
+  left: 20,
+  gap: vars.box.spacing[4],
+});
+
+export const iconWrapper = style({
+  position: "absolute",
+  bottom: vars.box.spacing[8],
+  right: vars.box.spacing[8],
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
 });

--- a/apps/web/src/domains/benefit/ui/components/benefit-card/index.tsx
+++ b/apps/web/src/domains/benefit/ui/components/benefit-card/index.tsx
@@ -1,5 +1,27 @@
+import { Box, GridItem } from "@nugudi/react-components-layout";
+import type { ReactNode } from "react";
 import * as styles from "./index.css";
 
-export const BenefitCard = () => {
-  return <div className={styles.card}>BenefitCard</div>;
+interface BenefitCardProps {
+  title: ReactNode;
+  description: ReactNode;
+  icon?: ReactNode;
+  onClick?: () => void;
+}
+
+export const BenefitCard = ({
+  title,
+  description,
+  icon,
+  onClick,
+}: BenefitCardProps) => {
+  return (
+    <GridItem className={styles.card} onClick={onClick}>
+      <Box className={styles.contentWrapper}>
+        {title}
+        {description}
+      </Box>
+      {icon && <Box className={styles.iconWrapper}>{icon}</Box>}
+    </GridItem>
+  );
 };

--- a/apps/web/src/domains/benefit/ui/components/benefit-menu-list/index.tsx
+++ b/apps/web/src/domains/benefit/ui/components/benefit-menu-list/index.tsx
@@ -6,7 +6,7 @@ import {
   FolderIcon,
   PenIcon,
 } from "@nugudi/assets-icons";
-import { VStack } from "@nugudi/react-components-layout";
+import { Body, VStack } from "@nugudi/react-components-layout";
 import { NavigationItem } from "@nugudi/react-components-navigation-item";
 
 export const BenefitMenuList = () => {
@@ -32,20 +32,23 @@ export const BenefitMenuList = () => {
   ];
 
   return (
-    <VStack gap="0">
+    <VStack gap={12}>
       {menuItems.map((item) => (
         <NavigationItem
+          size="md"
           key={item.id}
           leftIcon={<span>{item.icon}</span>}
           rightIcon={<ArrowRightIcon />}
           onClick={() => console.log(`Clicked ${item.id}`)}
         >
-          <div>
-            <div style={{ fontWeight: 500 }}>{item.title}</div>
-            <div style={{ fontSize: "14px", color: "#666", marginTop: "4px" }}>
+          <VStack gap={4}>
+            <Body fontSize="b3b" color="zinc" colorShade={500}>
+              {item.title}
+            </Body>
+            <Body fontSize="b4" color="zinc" colorShade={400}>
               {item.description}
-            </div>
-          </div>
+            </Body>
+          </VStack>
         </NavigationItem>
       ))}
     </VStack>

--- a/apps/web/src/domains/benefit/ui/components/benefit-menu-list/index.tsx
+++ b/apps/web/src/domains/benefit/ui/components/benefit-menu-list/index.tsx
@@ -1,28 +1,33 @@
 "use client";
 
-import { ArrowRightIcon } from "@nugudi/assets-icons";
+import {
+  ArrowRightIcon,
+  ExitIcon,
+  FolderIcon,
+  PenIcon,
+} from "@nugudi/assets-icons";
 import { VStack } from "@nugudi/react-components-layout";
 import { NavigationItem } from "@nugudi/react-components-navigation-item";
 
 export const BenefitMenuList = () => {
   const menuItems = [
     {
-      id: "mbit",
-      title: "밥 MBIT 검사하기",
+      id: "mbti",
+      title: "밥 MBTI 검사하기",
       description: "검사하고 매일 추천받기",
-      icon: "🎨", // 임시 아이콘
+      icon: <PenIcon />,
     },
     {
       id: "register",
       title: "구디 맛있는 구내식당 등록",
-      description: "20포인트 받기",
-      icon: "📁", // 임시 아이콘
+      description: "20 포인트 받기",
+      icon: <FolderIcon />,
     },
     {
       id: "request",
-      title: "식당 사제 요청",
-      description: "식당 사제에 관한 메시지",
-      icon: "✅", // 임시 아이콘
+      title: "식당 삭제 요청",
+      description: "식당 삭제에 관한 메시지",
+      icon: <ExitIcon />,
     },
   ];
 

--- a/apps/web/src/domains/benefit/ui/sections/user-benefit-section/index.tsx
+++ b/apps/web/src/domains/benefit/ui/sections/user-benefit-section/index.tsx
@@ -1,11 +1,36 @@
-import { HStack } from "@nugudi/react-components-layout";
+import { BusIcon, CameraIcon } from "@nugudi/assets-icons";
+import { Body, Emphasis, Grid } from "@nugudi/react-components-layout";
 import { BenefitCard } from "../../components/benefit-card";
 
 export const UserBenefitSection = () => {
   return (
-    <HStack gap="16">
-      <BenefitCard />
-      <BenefitCard />
-    </HStack>
+    <Grid gap={48} templateColumns="repeat(2, 1fr)" templateRows="auto">
+      <BenefitCard
+        title={
+          <Body fontSize="b3" color="main" colorShade={800}>
+            오늘의 식단 <br /> 사진 업로드
+          </Body>
+        }
+        description={
+          <Emphasis fontSize="e2" color="zinc" colorShade={400}>
+            제일 빠르게 올리고 <br /> 10 포인트 받기
+          </Emphasis>
+        }
+        icon={<CameraIcon width={70} height={70} />}
+      />
+      <BenefitCard
+        title={
+          <Body fontSize="b3" color="main" colorShade={800}>
+            구디 <br /> 구내식당 투어
+          </Body>
+        }
+        description={
+          <Emphasis fontSize="e2" color="zinc" colorShade={400}>
+            제일 빠르게 올리고 <br /> 10 포인트 받기
+          </Emphasis>
+        }
+        icon={<BusIcon width={70} height={70} />}
+      />
+    </Grid>
   );
 };

--- a/apps/web/src/domains/benefit/ui/views/benefit-page-view/index.tsx
+++ b/apps/web/src/domains/benefit/ui/views/benefit-page-view/index.tsx
@@ -1,4 +1,5 @@
 import { VStack } from "@nugudi/react-components-layout";
+import { AppHeader } from "@/src/shared/ui/components/app-header";
 import { BenefitListSection } from "../../sections/benefit-list-section";
 import { UserBenefitSection } from "../../sections/user-benefit-section";
 import * as styles from "./index.css";
@@ -7,6 +8,7 @@ export const BenefitPageView = () => {
   return (
     <div className={styles.container}>
       <VStack gap="16px">
+        <AppHeader />
         <UserBenefitSection />
         <BenefitListSection />
       </VStack>

--- a/apps/web/src/domains/restaurant/ui/views/home-view/index.tsx
+++ b/apps/web/src/domains/restaurant/ui/views/home-view/index.tsx
@@ -1,4 +1,5 @@
 import { Flex } from "@nugudi/react-components-layout";
+import { AppHeader } from "@/src/shared/ui/components/app-header";
 import UserWelcomeBanner from "@/src/shared/ui/components/user-welcome-banner";
 import BrowseMenuSection from "../../sections/browse-menu-section";
 import RecommendRestaurantSection from "../../sections/recommend-restaurant-section";
@@ -7,6 +8,7 @@ import * as styles from "./index.css";
 const HomeView = () => {
   return (
     <Flex direction="column" className={styles.container} gap="16px">
+      <AppHeader />
       <UserWelcomeBanner />
       <BrowseMenuSection />
       <RecommendRestaurantSection />

--- a/apps/web/src/shared/ui/components/app-header/index.css.ts
+++ b/apps/web/src/shared/ui/components/app-header/index.css.ts
@@ -1,7 +1,5 @@
-import { vars } from "@nugudi/themes";
 import { style } from "@vanilla-extract/css";
 
 export const container = style({
   width: "100%",
-  backgroundColor: vars.colors.$static.light.color.white,
 });

--- a/apps/web/src/shared/ui/components/app-header/index.css.ts
+++ b/apps/web/src/shared/ui/components/app-header/index.css.ts
@@ -1,0 +1,7 @@
+import { vars } from "@nugudi/themes";
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  width: "100%",
+  backgroundColor: vars.colors.$static.light.color.white,
+});

--- a/apps/web/src/shared/ui/components/app-header/index.tsx
+++ b/apps/web/src/shared/ui/components/app-header/index.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { LogoTextIcon, NotiIcon } from "@nugudi/assets-icons";
+import { Box, HStack } from "@nugudi/react-components-layout";
+import { vars } from "@nugudi/themes";
+import Link from "next/link";
+import * as styles from "./index.css";
+
+export const AppHeader = () => {
+  return (
+    <Box as="header" className={styles.container}>
+      <HStack pX="4" justify="space-between" align="center">
+        <Link href="/" aria-label="너구디 홈으로 이동">
+          <LogoTextIcon width={59} height={40} />
+        </Link>
+
+        <Link href="/notification" aria-label="알림 페이지로 이동">
+          <NotiIcon
+            width={24}
+            height={24}
+            color={vars.colors.$static.light.color.black}
+          />
+        </Link>
+      </HStack>
+    </Box>
+  );
+};

--- a/packages/react/components/layout/src/layout/Box.tsx
+++ b/packages/react/components/layout/src/layout/Box.tsx
@@ -29,6 +29,7 @@ const Box = (props: BoxProps, ref: React.Ref<HTMLElement>) => {
     sizeY,
     // Margin and padding properties with shorthands
     m,
+    margin,
     marginTop,
     marginRight,
     marginBottom,
@@ -40,6 +41,7 @@ const Box = (props: BoxProps, ref: React.Ref<HTMLElement>) => {
     mX,
     mY,
     p,
+    padding,
     paddingTop,
     paddingRight,
     paddingBottom,

--- a/packages/react/components/layout/src/layout/Flex.tsx
+++ b/packages/react/components/layout/src/layout/Flex.tsx
@@ -2,7 +2,6 @@ import { vars } from "@nugudi/themes";
 import { clsx } from "clsx";
 import * as React from "react";
 import { BaseStyle, StyleSprinkles } from "../core/style.css";
-import { extractSprinkleProps } from "../utils/properties";
 import type { FlexProps } from "./types";
 
 const Flex = (props: FlexProps, ref: React.Ref<HTMLElement>) => {
@@ -18,21 +17,113 @@ const Flex = (props: FlexProps, ref: React.Ref<HTMLElement>) => {
     shrink,
     wrap,
     gap,
+    // Width and height properties with shorthands
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties with shorthands
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
     children,
+    className,
+    style,
+    ...restProps
   } = props;
+
+  const sprinkleProps = {
+    // Width and height properties
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
+  };
 
   return React.createElement(
     as,
     {
-      ...props,
+      ...restProps,
       ref,
-      className: clsx([
-        BaseStyle,
-        StyleSprinkles(
-          extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
-        ),
-        props.className,
-      ]),
+      className: clsx([BaseStyle, StyleSprinkles(sprinkleProps), className]),
       style: {
         display: "flex",
         alignItems: align,
@@ -45,7 +136,7 @@ const Flex = (props: FlexProps, ref: React.Ref<HTMLElement>) => {
         gap,
         color: color && vars.colors.$scale?.[color]?.[700],
         background: background && vars.colors.$scale?.[background]?.[100],
-        ...props.style,
+        ...style,
       },
     },
     children,

--- a/packages/react/components/layout/src/layout/Grid.tsx
+++ b/packages/react/components/layout/src/layout/Grid.tsx
@@ -2,7 +2,6 @@ import { vars } from "@nugudi/themes";
 import { clsx } from "clsx";
 import * as React from "react";
 import { BaseStyle, StyleSprinkles } from "../core/style.css";
-import { extractSprinkleProps } from "../utils/properties";
 import type { GridProps } from "./types";
 
 const Grid = (props: GridProps, ref: React.Ref<HTMLElement>) => {
@@ -22,20 +21,112 @@ const Grid = (props: GridProps, ref: React.Ref<HTMLElement>) => {
     templateColumns,
     templateRows,
     templateAreas,
+    // Width and height properties with shorthands
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties with shorthands
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
+    className,
+    style,
+    ...restProps
   } = props;
+
+  const sprinkleProps = {
+    // Width and height properties
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
+  };
 
   return React.createElement(
     as,
     {
-      ...props,
+      ...restProps,
       ref,
-      className: clsx([
-        BaseStyle,
-        StyleSprinkles(
-          extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
-        ),
-        props.className,
-      ]),
+      className: clsx([BaseStyle, StyleSprinkles(sprinkleProps), className]),
       style: {
         display: "grid",
         gridAutoColumns: autoColumns,
@@ -51,7 +142,7 @@ const Grid = (props: GridProps, ref: React.Ref<HTMLElement>) => {
         gridRow: row,
         color: color && vars.colors.$scale?.[color]?.[500],
         background: background && vars.colors.$scale?.[background]?.[100],
-        ...props.style,
+        ...style,
       },
     },
     children,

--- a/packages/react/components/layout/src/layout/GridItem.tsx
+++ b/packages/react/components/layout/src/layout/GridItem.tsx
@@ -2,7 +2,6 @@ import { vars } from "@nugudi/themes";
 import { clsx } from "clsx";
 import * as React from "react";
 import { BaseStyle, StyleSprinkles } from "../core/style.css";
-import { extractSprinkleProps } from "../utils/properties";
 import type { GridItemProps } from "./types";
 
 const GridItem = (props: GridItemProps, ref: React.Ref<HTMLElement>) => {
@@ -18,20 +17,112 @@ const GridItem = (props: GridItemProps, ref: React.Ref<HTMLElement>) => {
     rowEnd,
     rowStart,
     rowSpan,
+    // Width and height properties with shorthands
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties with shorthands
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
+    className,
+    style,
+    ...restProps
   } = props;
+
+  const sprinkleProps = {
+    // Width and height properties
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
+  };
 
   return React.createElement(
     as,
     {
-      ...props,
+      ...restProps,
       ref,
-      className: clsx([
-        BaseStyle,
-        StyleSprinkles(
-          extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
-        ),
-        props.className,
-      ]),
+      className: clsx([BaseStyle, StyleSprinkles(sprinkleProps), className]),
       style: {
         gridArea: area,
         gridColumnEnd: colEnd,
@@ -42,7 +133,7 @@ const GridItem = (props: GridItemProps, ref: React.Ref<HTMLElement>) => {
         gridRow: rowSpan,
         color: color && vars.colors.$scale?.[color]?.[700],
         background: background && vars.colors.$scale?.[background]?.[100],
-        ...props.style,
+        ...style,
       },
     },
     children,

--- a/packages/react/components/layout/src/layout/HStack.tsx
+++ b/packages/react/components/layout/src/layout/HStack.tsx
@@ -3,7 +3,6 @@ import clsx from "clsx";
 import React from "react";
 import { BaseStyle, StyleSprinkles } from "@/core/style.css";
 import type { FlexProps as HStackProps } from "@/layout/types";
-import { extractSprinkleProps } from "@/utils/properties";
 
 const HStack = (props: HStackProps, ref: React.Ref<HTMLElement>) => {
   const {
@@ -17,20 +16,113 @@ const HStack = (props: HStackProps, ref: React.Ref<HTMLElement>) => {
     shrink,
     wrap,
     gap,
+    // Width and height properties with shorthands
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties with shorthands
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
     children,
+    className,
+    style,
+    ...restProps
   } = props;
+
+  const sprinkleProps = {
+    // Width and height properties
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
+  };
 
   return React.createElement(
     as,
     {
-      ...props,
+      ...restProps,
       ref,
-      className: clsx([
-        BaseStyle,
-        StyleSprinkles(
-          extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
-        ),
-      ]),
+      className: clsx([BaseStyle, StyleSprinkles(sprinkleProps), className]),
       style: {
         display: "flex",
         alignItems: align,
@@ -43,7 +135,7 @@ const HStack = (props: HStackProps, ref: React.Ref<HTMLElement>) => {
         gap,
         color: color && vars.colors.$scale?.[color]?.[700],
         background: background && vars.colors.$scale?.[background]?.[100],
-        ...props.style,
+        ...style,
       },
     },
     children,

--- a/packages/react/components/layout/src/layout/Stack.tsx
+++ b/packages/react/components/layout/src/layout/Stack.tsx
@@ -3,7 +3,6 @@ import clsx from "clsx";
 import React from "react";
 import { BaseStyle, StyleSprinkles } from "@/core/style.css";
 import type { FlexProps as StackProps } from "@/layout/types";
-import { extractSprinkleProps } from "@/utils/properties";
 
 const Stack = (props: StackProps, ref: React.Ref<HTMLElement>) => {
   const {
@@ -18,20 +17,113 @@ const Stack = (props: StackProps, ref: React.Ref<HTMLElement>) => {
     shrink,
     wrap,
     gap,
+    // Width and height properties with shorthands
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties with shorthands
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
     children,
+    className,
+    style,
+    ...restProps
   } = props;
+
+  const sprinkleProps = {
+    // Width and height properties
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
+  };
 
   return React.createElement(
     as,
     {
-      ...props,
+      ...restProps,
       ref,
-      className: clsx([
-        BaseStyle,
-        StyleSprinkles(
-          extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
-        ),
-      ]),
+      className: clsx([BaseStyle, StyleSprinkles(sprinkleProps), className]),
       style: {
         display: "flex",
         alignItems: align,
@@ -44,7 +136,7 @@ const Stack = (props: StackProps, ref: React.Ref<HTMLElement>) => {
         gap,
         color: color && vars.colors.$scale?.[color]?.[700],
         background: background && vars.colors.$scale?.[background]?.[100],
-        ...props.style,
+        ...style,
       },
     },
     children,

--- a/packages/react/components/layout/src/layout/VStack.tsx
+++ b/packages/react/components/layout/src/layout/VStack.tsx
@@ -3,7 +3,6 @@ import clsx from "clsx";
 import React from "react";
 import { BaseStyle, StyleSprinkles } from "@/core/style.css";
 import type { FlexProps as VStackProps } from "@/layout/types";
-import { extractSprinkleProps } from "@/utils/properties";
 
 const VStack = (props: VStackProps, ref: React.Ref<HTMLElement>) => {
   const {
@@ -17,20 +16,113 @@ const VStack = (props: VStackProps, ref: React.Ref<HTMLElement>) => {
     shrink,
     wrap,
     gap,
+    // Width and height properties with shorthands
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties with shorthands
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
     children,
+    className,
+    style,
+    ...restProps
   } = props;
+
+  const sprinkleProps = {
+    // Width and height properties
+    width,
+    w,
+    height,
+    h,
+    maxWidth,
+    maxW,
+    minWidth,
+    minW,
+    maxHeight,
+    maxH,
+    minHeight,
+    minH,
+    size,
+    maxSize,
+    minSize,
+    sizeX,
+    sizeY,
+    // Margin and padding properties
+    m,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    mt,
+    mr,
+    mb,
+    ml,
+    mX,
+    mY,
+    p,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    pt,
+    pr,
+    pb,
+    pl,
+    pX,
+    pY,
+    // Other style properties
+    borderRadius,
+    boxShadow,
+  };
 
   return React.createElement(
     as,
     {
-      ...props,
+      ...restProps,
       ref,
-      className: clsx([
-        BaseStyle,
-        StyleSprinkles(
-          extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
-        ),
-      ]),
+      className: clsx([BaseStyle, StyleSprinkles(sprinkleProps), className]),
       style: {
         display: "flex",
         alignItems: align,
@@ -43,7 +135,7 @@ const VStack = (props: VStackProps, ref: React.Ref<HTMLElement>) => {
         gap,
         color: color && vars.colors.$scale?.[color]?.[700],
         background: background && vars.colors.$scale?.[background]?.[100],
-        ...props.style,
+        ...style,
       },
     },
     children,

--- a/packages/react/components/navigation-item/src/style.css.ts
+++ b/packages/react/components/navigation-item/src/style.css.ts
@@ -17,6 +17,8 @@ export const navigationItemStyle = recipe({
       border: "none",
       backgroundColor: "transparent",
       padding: "8px 16px",
+      cursor: "pointer",
+      userSelect: "none",
 
       ":hover": {
         backgroundColor: vars.colors.$scale.zinc[50],


### PR DESCRIPTION
## 🌀 Issue Number
- #131 
<!-- #이슈번호 -->

## 😵 As-Is
  - `React 콘솔`에서 `pX`, `pY` 등 `커스텀 props`가 `DOM element`에 전달되어 경고 발생
  - `BenefitCard` 컴포넌트 디자인 미구현
  - `AppHeader` 컴포넌트 웹 접근성 미흡
<!-- 문제 상황 정의 -->

## 🥳 To-Be
  - 레이아웃 컴포넌트의 `DOM props` 이슈 해결 (명시적 destructuring 적용)
  - `BenefitCard` 컴포넌트 디자인 구현 
  - `AppHeader` 컴포넌트 구현 및 aria-label 접근성 개선
  - `BenefitPage` 구현
<!-- 변경 사항 -->

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)
<img width="616" height="967" alt="스크린샷 2025-08-30 오후 7 04 14" src="https://github.com/user-attachments/assets/ec4c2ded-b6f7-4b50-a95f-ffaab74939f1" />


## 👾 Additional Description (Optional)
@hijjoy 
`AppHeader` 컴포넌트를 layout이 아닌 각 페이지에서 직접 import하여 사용했습니다.
페이지별로 배경색이 다른 디자인 요구사항을 충족하기 위해, 추후 공용 컨테이너 컴포넌트로 확장할 예정입니다.