### PR TITLE
[NUGUDI-138] web 폰트 관련 설정 

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -36,10 +36,7 @@ const RootLayout = ({
 }>) => {
   return (
     <html lang="ko" suppressHydrationWarning={true}>
-      <body
-        className={`${Pretendard.variable}`}
-        suppressHydrationWarning={true}
-      >
+      <body className={Pretendard.className} suppressHydrationWarning={true}>
         <Providers>
           <MobileFirstLayout>{children}</MobileFirstLayout>
         </Providers>


### PR DESCRIPTION
## 🌀 Issue Number

<!-- #이슈번호 -->

- #158

## 😵 As-Is

<!-- 문제 상황 정의 -->

<img width="288" height="265" alt="스크린샷 2025-09-10 22 29 52" src="https://github.com/user-attachments/assets/cbf031c5-04e1-4097-a8d3-0fb82b8d1eea" />

프리텐다드 폰트가 적용되지 않고 있었습니다.

## 🥳 To-Be

<!-- 변경 사항 -->

https://nextjs.org/docs/app/getting-started/fonts
를 참고하여 폰트 적용 방식을 수정하였습니다.

<img width="324" height="278" alt="스크린샷 2025-09-10 22 29 16" src="https://github.com/user-attachments/assets/4f611b46-23ee-4cad-8fc2-1e6a0c949006" />


## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [ ] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)

## 👾 Additional Description (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 본문 요소의 글꼴 클래스 적용 방식을 업데이트하여 Pretendard 폰트가 보다 일관되게 표시되도록 조정했습니다. 시각적 결과 외 기능 변화는 없습니다. 전역 레이아웃의 구조와 속성은 기존과 동일하게 유지됩니다.
- 리팩터
  - 레이아웃의 body 태그 마크업을 단일 라인으로 정리해 가독성을 개선했습니다. 공개 인터페이스나 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->