### PR TITLE
[NUGUDI-146] 알림 페이지 UI 구현

### DIFF
--- a/apps/web/app/(auth)/notifications/page.tsx
+++ b/apps/web/app/(auth)/notifications/page.tsx
@@ -1,6 +1,7 @@
-// 알림 목록 페이지
+import { NotificationView } from "@/src/domains/notification/ui/views/notification-view";
+
 const NotificationsPage = () => {
-  return <div>NotificationsPage</div>;
+  return <NotificationView />;
 };
 
 export default NotificationsPage;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "@sentry/nextjs": "^9.31.0",
     "@tanstack/react-query": "^5.81.2",
     "@vanilla-extract/recipes": "^0.5.7",
+    "clsx": "^2.1.1",
     "next": "15.4.6",
     "pretendard": "^1.3.9",
     "react": "^19.1.1",

--- a/apps/web/src/domains/notification/constants/notification.ts
+++ b/apps/web/src/domains/notification/constants/notification.ts
@@ -1,0 +1,69 @@
+import type { NotificationItem } from "../types/notification";
+
+export const MOCK_NOTIFICATIONS: NotificationItem[] = [
+  {
+    id: "1",
+    type: "review",
+    title: "초코합우유 님이 댓글을 남겼어요",
+    content: "[팰런티어] 민초버널라님 팰런티어는 9월 46000원 할때도 10월 55...",
+    timestamp: "1일 전",
+    isRead: false,
+    link: "/reviews/35",
+  },
+  {
+    id: "2",
+    type: "menu",
+    title: "오늘의 구내식당 메뉴가 올라왔어요",
+    content: "점심 메뉴: 제육볶음, 된장찌개, 계란말이가 준비되어 있습니다.",
+    timestamp: "1일 전",
+    isRead: false,
+  },
+  {
+    id: "3",
+    type: "event",
+    title: "이번 주 특가 메뉴",
+    content: "금요일 특식! 돈가스가 5,000원 → 3,500원으로 할인됩니다.",
+    timestamp: "1일 전",
+    isRead: false,
+  },
+  {
+    id: "4",
+    type: "notice",
+    title: "[구내식당] 운영시간 변경 안내",
+    content: "12월 24일부터 점심시간이 11:30~13:30으로 변경됩니다.",
+    timestamp: "1일 전",
+    isRead: false,
+  },
+  {
+    id: "5",
+    type: "point",
+    title: "포인트가 적립되었어요",
+    content: "구내식당 리뷰 작성으로 100포인트가 적립되었습니다.",
+    timestamp: "1일 전",
+    isRead: true,
+  },
+  {
+    id: "6",
+    type: "menu",
+    title: "내일 구내식당 메뉴가 올라왔어요",
+    content: "특식 예정: 갈비탕, 김치전, 나물 반찬이 제공됩니다.",
+    timestamp: "1일 전",
+    isRead: false,
+  },
+  {
+    id: "7",
+    type: "review",
+    title: "내 리뷰에 좋아요를 눌렀어요",
+    content: "어제 작성한 한식당 리뷰에 15명이 좋아요를 눌렀습니다.",
+    timestamp: "1일 전",
+    isRead: false,
+  },
+];
+
+export const NOTIFICATION_TYPE_LABELS = {
+  point: "포인트",
+  review: "리뷰",
+  menu: "메뉴",
+  event: "이벤트",
+  notice: "공지",
+} as const;

--- a/apps/web/src/domains/notification/types/notification.ts
+++ b/apps/web/src/domains/notification/types/notification.ts
@@ -1,0 +1,17 @@
+export type NotificationType = "point" | "review" | "menu" | "event" | "notice";
+
+export interface NotificationItem {
+  id: string;
+  type: NotificationType;
+  title: string;
+  content: string;
+  timestamp: string;
+  isRead: boolean;
+  icon?: string;
+  link?: string;
+}
+
+export interface NotificationGroup {
+  date: string;
+  items: NotificationItem[];
+}

--- a/apps/web/src/domains/notification/types/notification.ts
+++ b/apps/web/src/domains/notification/types/notification.ts
@@ -10,8 +10,3 @@ export interface NotificationItem {
   icon?: string;
   link?: string;
 }
-
-export interface NotificationGroup {
-  date: string;
-  items: NotificationItem[];
-}

--- a/apps/web/src/domains/notification/ui/components/notification-empty/index.css.ts
+++ b/apps/web/src/domains/notification/ui/components/notification-empty/index.css.ts
@@ -1,0 +1,28 @@
+import { vars } from "@nugudi/themes";
+import { style } from "@vanilla-extract/css";
+
+export const emptyContainer = style({
+  padding: `${vars.box.spacing[60]} ${vars.box.spacing[20]}`,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: "400px",
+});
+
+export const emptyIcon = style({
+  width: 64,
+  height: 64,
+  color: vars.colors.$scale.zinc[300],
+});
+
+export const emptyTitle = style({
+  color: vars.colors.$scale.zinc[700],
+  fontWeight: 500,
+  textAlign: "center",
+});
+
+export const emptyDescription = style({
+  color: vars.colors.$scale.zinc[500],
+  textAlign: "center",
+});

--- a/apps/web/src/domains/notification/ui/components/notification-empty/index.tsx
+++ b/apps/web/src/domains/notification/ui/components/notification-empty/index.tsx
@@ -1,0 +1,19 @@
+import { NotiIcon } from "@nugudi/assets-icons";
+import { Body, Emphasis, VStack } from "@nugudi/react-components-layout";
+import * as styles from "./index.css";
+
+export const NotificationEmpty = () => {
+  return (
+    <VStack gap={16} align="center" className={styles.emptyContainer}>
+      <NotiIcon className={styles.emptyIcon} />
+      <VStack gap={8} align="center">
+        <Body fontSize="b2" className={styles.emptyTitle}>
+          알림이 없습니다
+        </Body>
+        <Emphasis fontSize="e1" className={styles.emptyDescription}>
+          새로운 알림이 도착하면 여기에 표시됩니다
+        </Emphasis>
+      </VStack>
+    </VStack>
+  );
+};

--- a/apps/web/src/domains/notification/ui/components/notification-item/index.css.ts
+++ b/apps/web/src/domains/notification/ui/components/notification-item/index.css.ts
@@ -24,10 +24,6 @@ export const unread = style({
   },
 });
 
-export const read = style({
-  backgroundColor: "white",
-});
-
 export const iconWrapper = style({
   flexShrink: 0,
   display: "flex",
@@ -71,17 +67,6 @@ export const timestamp = style({
   flexShrink: 0,
   marginLeft: vars.box.spacing[8],
   fontSize: "12px",
-});
-
-export const linkText = style({
-  color: vars.colors.$scale.blue[600],
-  marginTop: vars.box.spacing[2],
-  cursor: "pointer",
-  fontSize: "12px",
-
-  ":hover": {
-    textDecoration: "underline",
-  },
 });
 
 export const iconStyle = style({

--- a/apps/web/src/domains/notification/ui/components/notification-item/index.css.ts
+++ b/apps/web/src/domains/notification/ui/components/notification-item/index.css.ts
@@ -1,0 +1,90 @@
+import { vars } from "@nugudi/themes";
+import { style } from "@vanilla-extract/css";
+
+export const notificationItem = style({
+  padding: `${vars.box.spacing[8]}`,
+  cursor: "pointer",
+  transition: "background-color 0.2s ease",
+  borderBottom: `1px solid ${vars.colors.$scale.zinc[100]}`,
+
+  ":hover": {
+    backgroundColor: vars.colors.$scale.zinc[50],
+  },
+
+  ":active": {
+    backgroundColor: vars.colors.$scale.zinc[100],
+  },
+});
+
+export const unread = style({
+  backgroundColor: vars.colors.$scale.main[50],
+
+  ":hover": {
+    backgroundColor: vars.colors.$scale.main[100],
+  },
+});
+
+export const read = style({
+  backgroundColor: "white",
+});
+
+export const iconWrapper = style({
+  flexShrink: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 36,
+  height: 36,
+  borderRadius: "50%",
+  backgroundColor: vars.colors.$scale.zinc[100],
+  color: vars.colors.$scale.zinc[600],
+});
+
+export const contentWrapper = style({
+  flex: 1,
+  minWidth: 0,
+});
+
+export const title = style({
+  color: vars.colors.$scale.zinc[800],
+  fontWeight: 500,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  flex: 1,
+  fontSize: "14px",
+  lineHeight: 1.3,
+});
+
+export const content = style({
+  color: vars.colors.$scale.zinc[600],
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  lineHeight: 1.3,
+  fontSize: "13px",
+  marginTop: "2px",
+});
+
+export const timestamp = style({
+  color: vars.colors.$scale.zinc[400],
+  flexShrink: 0,
+  marginLeft: vars.box.spacing[8],
+  fontSize: "12px",
+});
+
+export const linkText = style({
+  color: vars.colors.$scale.blue[600],
+  marginTop: vars.box.spacing[2],
+  cursor: "pointer",
+  fontSize: "12px",
+
+  ":hover": {
+    textDecoration: "underline",
+  },
+});
+
+export const iconStyle = style({
+  width: "20px",
+  height: "20px",
+});

--- a/apps/web/src/domains/notification/ui/components/notification-item/index.tsx
+++ b/apps/web/src/domains/notification/ui/components/notification-item/index.tsx
@@ -8,7 +8,8 @@ import {
   NotiIcon,
 } from "@nugudi/assets-icons";
 import { Avatar } from "@nugudi/react-components-avatar";
-import { Box, Flex, HStack } from "@nugudi/react-components-layout";
+import { Box, Emphasis, Flex, HStack } from "@nugudi/react-components-layout";
+import clsx from "clsx";
 import type { NotificationItem } from "../../../types/notification";
 import * as styles from "./index.css";
 
@@ -26,7 +27,7 @@ export function NotificationItemCard({
 
   return (
     <Box
-      className={`${styles.notificationItem} ${isUnread ? styles.unread : styles.read}`}
+      className={clsx(styles.notificationItem, isUnread && styles.unread)}
       onClick={handleClick}
     >
       <HStack gap={24} align="center" justify="center">
@@ -98,5 +99,9 @@ function NotificationItemAction({ notification }: NotificationItemActionProps) {
     return null;
   }
 
-  return <span className={styles.linkText}>35건 더보기</span>;
+  return (
+    <Emphasis mt={2} fontSize="e1" as="span" color="blue">
+      자세히 보기
+    </Emphasis>
+  );
 }

--- a/apps/web/src/domains/notification/ui/components/notification-item/index.tsx
+++ b/apps/web/src/domains/notification/ui/components/notification-item/index.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import {
+  BreadIcon,
+  CoinIcon,
+  CommentIcon,
+  GiftIcon,
+  NotiIcon,
+} from "@nugudi/assets-icons";
+import { Avatar } from "@nugudi/react-components-avatar";
+import { Box, Flex, HStack } from "@nugudi/react-components-layout";
+import type { NotificationItem } from "../../../types/notification";
+import * as styles from "./index.css";
+
+interface NotificationItemProps {
+  notification: NotificationItem;
+  onClick?: (notification: NotificationItem) => void;
+}
+
+export function NotificationItemCard({
+  notification,
+  onClick,
+}: NotificationItemProps) {
+  const handleClick = () => onClick?.(notification);
+  const isUnread = !notification.isRead;
+
+  return (
+    <Box
+      className={`${styles.notificationItem} ${isUnread ? styles.unread : styles.read}`}
+      onClick={handleClick}
+    >
+      <HStack gap={24} align="center" justify="center">
+        <NotificationItemAvatar notification={notification} />
+        <Flex direction="column" className={styles.contentWrapper}>
+          <NotificationItemHeader notification={notification} />
+          <NotificationItemContent notification={notification} />
+          <NotificationItemAction notification={notification} />
+        </Flex>
+      </HStack>
+    </Box>
+  );
+}
+
+interface NotificationItemAvatarProps
+  extends Pick<NotificationItemProps, "notification"> {}
+
+function NotificationItemAvatar({ notification }: NotificationItemAvatarProps) {
+  const getIcon = (type: NotificationItem["type"]) => {
+    switch (type) {
+      case "point":
+        return <CoinIcon className={styles.iconStyle} />;
+      case "review":
+        return <CommentIcon className={styles.iconStyle} />;
+      case "menu":
+        return <BreadIcon className={styles.iconStyle} />;
+      case "event":
+        return <GiftIcon className={styles.iconStyle} />;
+      case "notice":
+        return <NotiIcon className={styles.iconStyle} />;
+      default:
+        return <NotiIcon className={styles.iconStyle} />;
+    }
+  };
+
+  if (notification.icon) {
+    return <Avatar src={notification.icon} size="sm" />;
+  }
+
+  return <Box className={styles.iconWrapper}>{getIcon(notification.type)}</Box>;
+}
+
+interface NotificationItemHeaderProps
+  extends Pick<NotificationItemProps, "notification"> {}
+
+function NotificationItemHeader({ notification }: NotificationItemHeaderProps) {
+  return (
+    <HStack justify="space-between" align="flex-start">
+      <span className={styles.title}>{notification.title}</span>
+      <span className={styles.timestamp}>{notification.timestamp}</span>
+    </HStack>
+  );
+}
+
+interface NotificationItemContentProps
+  extends Pick<NotificationItemProps, "notification"> {}
+
+function NotificationItemContent({
+  notification,
+}: NotificationItemContentProps) {
+  return <span className={styles.content}>{notification.content}</span>;
+}
+
+interface NotificationItemActionProps
+  extends Pick<NotificationItemProps, "notification"> {}
+
+function NotificationItemAction({ notification }: NotificationItemActionProps) {
+  if (!notification.link) {
+    return null;
+  }
+
+  return <span className={styles.linkText}>35건 더보기</span>;
+}

--- a/apps/web/src/domains/notification/ui/sections/notification-list-section/index.css.ts
+++ b/apps/web/src/domains/notification/ui/sections/notification-list-section/index.css.ts
@@ -1,0 +1,7 @@
+import { style } from "@vanilla-extract/css";
+
+export const listContainer = style({
+  width: "100%",
+  backgroundColor: "white",
+  minHeight: "100vh",
+});

--- a/apps/web/src/domains/notification/ui/sections/notification-list-section/index.css.ts
+++ b/apps/web/src/domains/notification/ui/sections/notification-list-section/index.css.ts
@@ -1,7 +1,7 @@
+import { vars } from "@nugudi/themes";
 import { style } from "@vanilla-extract/css";
 
 export const listContainer = style({
   width: "100%",
-  backgroundColor: "white",
-  minHeight: "100vh",
+  backgroundColor: vars.colors.$scale.whiteAlpha[100],
 });

--- a/apps/web/src/domains/notification/ui/sections/notification-list-section/index.tsx
+++ b/apps/web/src/domains/notification/ui/sections/notification-list-section/index.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { VStack } from "@nugudi/react-components-layout";
+import { MOCK_NOTIFICATIONS } from "../../../constants/notification";
+import { NotificationEmpty } from "../../components/notification-empty";
+import { NotificationItemCard } from "../../components/notification-item";
+import * as styles from "./index.css";
+
+export const NotificationListSection = () => {
+  if (MOCK_NOTIFICATIONS.length === 0) {
+    return <NotificationEmpty />;
+  }
+
+  return (
+    <VStack className={styles.listContainer}>
+      {MOCK_NOTIFICATIONS.map((notification) => (
+        <NotificationItemCard
+          key={notification.id}
+          notification={notification}
+        />
+      ))}
+    </VStack>
+  );
+};

--- a/apps/web/src/domains/notification/ui/views/notification-view/index.css.ts
+++ b/apps/web/src/domains/notification/ui/views/notification-view/index.css.ts
@@ -1,0 +1,5 @@
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  width: "100%",
+});

--- a/apps/web/src/domains/notification/ui/views/notification-view/index.tsx
+++ b/apps/web/src/domains/notification/ui/views/notification-view/index.tsx
@@ -1,0 +1,13 @@
+import { Flex } from "@nugudi/react-components-layout";
+import { NavBar } from "@/src/shared/ui/components/nav-bar";
+import { NotificationListSection } from "../../sections/notification-list-section";
+import * as styles from "./index.css";
+
+export const NotificationView = () => {
+  return (
+    <Flex direction="column" gap={0} className={styles.container}>
+      <NavBar title="알림" />
+      <NotificationListSection />
+    </Flex>
+  );
+};

--- a/apps/web/src/shared/ui/components/nav-bar/index.css.ts
+++ b/apps/web/src/shared/ui/components/nav-bar/index.css.ts
@@ -8,6 +8,7 @@ export const container = style({
   top: 0,
   zIndex: 1,
   transition: "transform 0.3s ease",
+  padding: `${vars.box.spacing[2]}`,
 });
 
 export const hidden = style({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@vanilla-extract/recipes':
         specifier: ^0.5.7
         version: 0.5.7(@vanilla-extract/css@1.17.4)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: 15.4.6
         version: 15.4.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)


### PR DESCRIPTION
## 🌀 Issue Number
- #163 
<!-- #이슈번호 -->

## 😵 As-Is
  알림 페이지 UI가 구현되지 않은 상태
<!-- 문제 상황 정의 -->

## 🥳 To-Be
  - 알림 페이지 UI 구현 (View → Section → Component 구조)
  - 읽지 않은 알림: 테마 메인 컬러(녹색) 배경
  - 읽은 알림: 흰색 배경
  - 구내식당 서비스 컨텍스트에 맞는 알림 타입 구현
    - 포인트, 리뷰, 메뉴, 이벤트, 공지
  - SRP 원칙 적용한 컴포넌트 구조

<!-- 변경 사항 -->

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)
<img width="614" height="928" alt="스크린샷 2025-09-18 오후 6 04 42" src="https://github.com/user-attachments/assets/790cb56a-10ef-4880-a3f6-678c7edc948e" />

## 👾 Additional Description (Optional)
  - notification-view → notification-list-section → notification-item, notification-empty 컴포넌트 구조
  - 실제 관련 스펙이 나오지 않은 관계로 Mock 데이터로 구내식당 서비스 시나리오 구현
  
  추후 스펙이 확정되면 별도의 스토리북으로 분리 할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 알림 화면을 도입하여 상단 내비게이션과 함께 알림 목록을 제공합니다.
  - 빈 상태 화면을 추가해 알림이 없을 때 안내를 보여줍니다.
  - 알림 카드 컴포넌트를 통해 제목, 내용, 시간, 읽음 상태, 액션 링크를 표시합니다.
  - 알림 유형에 대한 한글 라벨을 적용하고 목업 데이터로 초기 렌더링합니다.
- 스타일
  - 알림 뷰/리스트/아이템/빈 상태 전용 스타일을 추가했습니다.
  - 내비게이션 바 패딩을 조정해 시각적 일관성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->