### PR TITLE
[NUGUDI-148] 아이콘 패키지 수정

### DIFF
--- a/packages/assets/icons/README.md
+++ b/packages/assets/icons/README.md
@@ -2,7 +2,7 @@
 
 ## 📝 새 아이콘 추가하기
 
-새로운 아이콘을 추가하려면 다음 4단계를 따라주세요:
+새로운 아이콘을 추가하려면 다음 3단계를 따라주세요:
 
 ### 1. SVG 파일 추가
 
@@ -12,19 +12,13 @@ SVG 파일을 `svg/` 폴더에 넣어주세요.
 packages/assets/icons/svg/new-icon.svg
 ```
 
-### 2. 아이콘 컴포넌트 import 추가
+### 2. iconRegistry에 등록
 
-`src/icons.ts` 파일의 import 섹션에 추가해주세요:
+`src/registry.ts` 파일의 `iconRegistry` 객체에 아이콘을 등록해주세요:
 
 ```typescript
 import NewIcon from "../svg/new-icon.svg?react";
-```
 
-### 3. iconRegistry에 등록
-
-`src/icons.ts` 파일의 `iconRegistry` 객체에 아이콘을 등록해주세요:
-
-```typescript
 export const iconRegistry: IconRegistry = {
   // ... 기존 아이콘들
   NewIcon: {
@@ -34,7 +28,7 @@ export const iconRegistry: IconRegistry = {
 };
 ```
 
-### 4. index.ts에 export 추가
+### 3. index.ts에 export 추가
 
 `src/index.ts` 파일에 export를 추가해주세요:
 

--- a/packages/assets/icons/package.json
+++ b/packages/assets/icons/package.json
@@ -17,8 +17,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build",

--- a/packages/assets/icons/package.json
+++ b/packages/assets/icons/package.json
@@ -2,11 +2,16 @@
   "name": "@nugudi/assets-icons",
   "version": "0.0.0",
   "private": false,
+  "sideEffects": false,
   "type": "module",
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./registry": {
+      "import": "./dist/registry.js",
+      "types": "./dist/registry.d.ts"
     }
   },
   "main": "./dist/index.js",

--- a/packages/assets/icons/src/index.ts
+++ b/packages/assets/icons/src/index.ts
@@ -1,4 +1,3 @@
-export { iconRegistry, icons, searchIcons } from "./icons";
 export { default as AppleIcon } from "./svg/apple.svg?react";
 export { default as ArrowLeftIcon } from "./svg/arrow-left.svg?react";
 export { default as ArrowRightIcon } from "./svg/arrow-right.svg?react";

--- a/packages/assets/icons/src/registry.ts
+++ b/packages/assets/icons/src/registry.ts
@@ -1,4 +1,3 @@
-// Icon imports
 import AppleIcon from "./svg/apple.svg?react";
 import ArrowLeftIcon from "./svg/arrow-left.svg?react";
 import ArrowRightIcon from "./svg/arrow-right.svg?react";

--- a/packages/assets/icons/vite.config.ts
+++ b/packages/assets/icons/vite.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
     },
     rollupOptions: {
       external: ["react", "react-dom"],
+      output: {
+        preserveModules: true,
+        preserveModulesRoot: "src",
+        entryFileNames: "[name].js",
+      },
     },
   },
   resolve: {

--- a/packages/react/components/menu-card/src/constants/category-config.ts
+++ b/packages/react/components/menu-card/src/constants/category-config.ts
@@ -1,4 +1,15 @@
-import { icons } from "@nugudi/assets-icons";
+import {
+  AppleIcon,
+  BreadIcon,
+  EtcIcon,
+  MajorDishIcon,
+  NoodleIcon,
+  PicklesIcon,
+  RiceIcon,
+  SoupIcon,
+  SubDishIcon,
+  TeaIcon,
+} from "@nugudi/assets-icons";
 import type { ComponentType, SVGProps } from "react";
 import type { MenuCategory } from "../types";
 
@@ -14,43 +25,43 @@ export const CATEGORY_CONFIG: Record<
   }
 > = {
   RICE: {
-    Icon: icons.Rice.component,
+    Icon: RiceIcon,
     label: "밥류",
   },
   NOODLE: {
-    Icon: icons.Noodle.component,
+    Icon: NoodleIcon,
     label: "면류",
   },
   SOUP: {
-    Icon: icons.Soup.component,
+    Icon: SoupIcon,
     label: "국/탕/찌개",
   },
   MAIN_DISH: {
-    Icon: icons.MajorDish.component,
+    Icon: MajorDishIcon,
     label: "주요 반찬",
   },
   SIDE_DISH: {
-    Icon: icons.SubDish.component,
+    Icon: SubDishIcon,
     label: "서브반찬",
   },
   KIMCHI: {
-    Icon: icons.Pickles.component,
+    Icon: PicklesIcon,
     label: "김치 절임류",
   },
   BREAD_SANDWICH: {
-    Icon: icons.Bread.component,
+    Icon: BreadIcon,
     label: "빵토스트샌드위치",
   },
   SALAD_FRUIT: {
-    Icon: icons.Apple.component,
+    Icon: AppleIcon,
     label: "샐러드 / 과일",
   },
   DRINK: {
-    Icon: icons.Tea.component,
+    Icon: TeaIcon,
     label: "음료 후식류",
   },
   OTHER: {
-    Icon: icons.Etc.component,
+    Icon: EtcIcon,
     label: "기타",
   },
 };

--- a/packages/ui/src/foundations/icons.stories.tsx
+++ b/packages/ui/src/foundations/icons.stories.tsx
@@ -1,4 +1,4 @@
-import { iconRegistry, searchIcons } from "@nugudi/assets-icons";
+import { iconRegistry, searchIcons } from "@nugudi/assets-icons/registry";
 import { useState } from "react";
 import {
   iconCode,


### PR DESCRIPTION
## 🌀 Issue Number

- #165


## 😵 As-Is

<!-- 문제 상황 정의 -->

<img width="500" height="1117" alt="스크린샷 2025-09-19 10 28 20" src="https://github.com/user-attachments/assets/992e8d76-c744-42a9-aec7-3af4c312f33c" />

web에서 해당 부분만큼 icon이 차지하고있습니다.
아이콘 검색을 위한 registry는 web에서는 실제로 불러올 필요가 없지만, 해당 부분까지 포함되어 있었습니다.


## 🥳 To-Be

<!-- 변경 사항 -->

<img width="500" height="825" alt="스크린샷 2025-09-19 10 39 44" src="https://github.com/user-attachments/assets/aef8e3d7-aaae-4463-b367-c9ffc5b76d42" />

- PreserveModules: true 옵션을 사용하여 아이콘을 개별 파일로 분리
- sideEffects: false 사용 (DOM을 조작하거나, CSS 파일을 불러오는 부수효과 없음)
- registry를 위한 진입점을 분리하여 실수로라도 불러오지 않도록 수정하였습니다 




## ✅ Check List

- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)

## 👾 Additional Description (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 문서(Documentation)
  - 아이콘 추가 가이드를 4단계에서 3단계로 간소화하고 예시 및 내보내기 예제를 최신 흐름에 맞게 업데이트했습니다.
- 리팩터(Refactor)
  - 공개 API에서 iconRegistry, icons, searchIcons 재노출을 제거했습니다. 필요 시 별도 레지스트리 경로로 가져오세요.
  - UI 스토리 및 컴포넌트의 아이콘 임포트 경로를 레지스트리 경로로 변경했습니다.
- 작업(Chores)
  - 트리 쉐이킹 개선을 위해 sideEffects: false 적용.
  - 공개 경로에 레지스트리 엔트리 추가 및 배포 파일을 dist로 정리.
  - 빌드 출력 구성을 모듈 보존 방식으로 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->