### PR TITLE
[NUGUDI-165] 토큰 갱신 시 X-Device-ID 헤더 누락 수정 및 로깅 통일화

### DIFF
--- a/apps/web/src/domains/auth/profile/ui/components/profile-logout-button/index.tsx
+++ b/apps/web/src/domains/auth/profile/ui/components/profile-logout-button/index.tsx
@@ -4,14 +4,17 @@ import { Button } from "@nugudi/react-components-button";
 import * as styles from "./index.css";
 
 export const ProfileLogoutButton = () => {
+  const handleLogout = () => {
+    // TODO: 로그아웃 API 호출
+    window.location.href = "/api/auth/logout";
+  };
+
   return (
     <Button
       variant="neutral"
       size="sm"
       color={"whiteAlpha"}
-      onClick={() => {
-        console.log("logout");
-      }}
+      onClick={handleLogout}
       className={styles.buttonBox}
     >
       로그아웃

--- a/apps/web/src/domains/auth/providers/kakao-provider.ts
+++ b/apps/web/src/domains/auth/providers/kakao-provider.ts
@@ -53,6 +53,7 @@ export class KakaoProvider implements OAuthProvider {
 
       const userAgent = request.headers.get("user-agent") || "Unknown";
       const deviceInfo = createDeviceInfo(userAgent);
+      const deviceId = deviceInfo.deviceUniqueId;
 
       const response = await kakaoLogin({
         code,
@@ -107,6 +108,7 @@ export class KakaoProvider implements OAuthProvider {
           refreshToken: data.refreshToken,
         },
         provider: "kakao",
+        deviceId,
       };
     } catch (error) {
       if (error instanceof AuthError) throw error;

--- a/apps/web/src/domains/auth/sign-in/ui/components/sign-in-email-form/index.tsx
+++ b/apps/web/src/domains/auth/sign-in/ui/components/sign-in-email-form/index.tsx
@@ -34,8 +34,8 @@ const SignInEmailForm = () => {
     mode: "onTouched",
   });
 
-  const onSubmit = (data: FormData) => {
-    console.log("Form submitted:", data);
+  const onSubmit = (_data: FormData) => {
+    // TODO: 이메일 로그인 API 연동
   };
 
   const togglePasswordVisibility = () => {

--- a/apps/web/src/domains/auth/types/session.ts
+++ b/apps/web/src/domains/auth/types/session.ts
@@ -25,6 +25,7 @@ export interface Session {
   user: User;
   tokenSet: TokenSet;
   provider: ProviderType;
+  deviceId: string;
 }
 
 /**

--- a/apps/web/src/domains/auth/utils/auth-client.ts
+++ b/apps/web/src/domains/auth/utils/auth-client.ts
@@ -205,6 +205,7 @@ export class AuthClient {
       const response = await refreshToken({
         headers: {
           Authorization: `Bearer ${session.tokenSet.refreshToken}`,
+          "X-Device-ID": session.deviceId,
         },
       });
 
@@ -241,6 +242,7 @@ export class AuthClient {
       const response = await refreshToken({
         headers: {
           Authorization: `Bearer ${session.tokenSet.refreshToken}`,
+          "X-Device-ID": session.deviceId,
         },
       });
 

--- a/apps/web/src/domains/cafeteria/request-register/ui/components/request-register-form/steps/cafeteria-info-form/index.tsx
+++ b/apps/web/src/domains/cafeteria/request-register/ui/components/request-register-form/steps/cafeteria-info-form/index.tsx
@@ -34,9 +34,8 @@ export const CafeteriaInfoForm = ({ onNext }: CafeteriaInfoFormProps) => {
     },
   });
 
-  const onSubmit = (data: CafeteriaInfoFormData) => {
+  const onSubmit = (_data: CafeteriaInfoFormData) => {
     // TODO: API 호출로 데이터 전송
-    console.log("제출 데이터:", data);
     onNext();
   };
 
@@ -46,7 +45,6 @@ export const CafeteriaInfoForm = ({ onNext }: CafeteriaInfoFormProps) => {
 
   const handleImageUpload = () => {
     // TODO: 이미지 업로드 기능 구현
-    console.log("이미지 업로드");
   };
 
   return (

--- a/apps/web/src/domains/cafeteria/reviews/write/ui/sections/review-write-section/index.tsx
+++ b/apps/web/src/domains/cafeteria/reviews/write/ui/sections/review-write-section/index.tsx
@@ -40,10 +40,9 @@ export const ReviewWriteSection = ({
     return [...currentRatings, rating];
   };
 
-  const onSubmit = async (data: ReviewFormData) => {
+  const onSubmit = async (_data: ReviewFormData) => {
     // TODO: API 호출 구현
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    console.log("Submitting review:", { cafeteriaId, ...data });
   };
 
   return (

--- a/apps/web/src/domains/stamp/ui/components/stamp-verify-form/index.tsx
+++ b/apps/web/src/domains/stamp/ui/components/stamp-verify-form/index.tsx
@@ -30,7 +30,6 @@ export const StampVerifyForm = () => {
       return;
     }
     // TODO: API 호출하여 이미지 업로드 및 인증 처리
-    console.log("Submit:", uploadedImage);
   };
 
   return (

--- a/apps/web/src/shared/configs/pwa/register-service-worker.ts
+++ b/apps/web/src/shared/configs/pwa/register-service-worker.ts
@@ -1,3 +1,5 @@
+import { logger } from "@/src/lib/logger";
+
 export const registerServiceWorker = () => {
   if (typeof window === "undefined") return;
 
@@ -6,10 +8,14 @@ export const registerServiceWorker = () => {
       navigator.serviceWorker
         .register("/pwaServiceWorker.js")
         .then((registration) => {
-          console.info("Service Worker registered:", registration);
+          logger.info("Service Worker registered successfully", {
+            scope: registration.scope,
+          });
         })
         .catch((error) => {
-          console.error("Service Worker registration failed:", error);
+          logger.error("Service Worker registration failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
     });
   }


### PR DESCRIPTION
## 🌀 Issue Number
- #179 
<!-- #이슈번호 -->

## 😵 As-Is
  - Middleware와 auth-client에서 console.error 사용으로 구조화된 로깅 불가
  - getSession()이 기본적으로 토큰 갱신을 수행하여 Middleware와 중복 체크 발생
  - 개발용 console.log가 프로덕션 코드에 남아있음
  - 로그아웃 버튼이 실제 동작하지 않음
<!-- 문제 상황 정의 -->

## 🥳 To-Be
  - 모든 에러 로깅을 logger로 통일하고 AuthError 구조화된 로깅 지원
  - getSession() 기본값을 refresh: false로 변경하여 Middleware에서만 토큰 갱신 수행 (성능 최적화)
  - Service Worker 등록 로깅도 logger로 통일
  - 불필요한 개발용 로그 제거 및 로그아웃 기능 구현
<!-- 변경 사항 -->

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)

## 👾 Additional Description (Optional)
  주요 개선사항:
  - 에러 추적성 향상: logger로 통일하여 모니터링 시스템 연동 준비
  - 성능 개선: Server Component에서 불필요한 JWT 파싱 제거
  - 코드 품질: 개발용 디버그 코드 정리