### PR TITLE
[NUGUDI-167] 네이버 소셜 로그인 기능 구현 및, DRY 미준수에 따른 코드 리팩토링

### DIFF
--- a/apps/web/app/api/auth/sign-up/social/route.ts
+++ b/apps/web/app/api/auth/sign-up/social/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
       deviceId,
     };
 
-    // 세션 저장
+    // 세션 저장 (setSession 내부에서 deviceId도 쿠키로 저장됨)
     await auth.setSession(session);
 
     return NextResponse.json({ success: true });

--- a/apps/web/src/domains/auth/actions/get-or-create-device-id.ts
+++ b/apps/web/src/domains/auth/actions/get-or-create-device-id.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+/**
+ * Server-Side에서 Device ID를 가져오거나 생성합니다.
+ * httpOnly 쿠키로 저장하여 클라이언트에서 접근할 수 없도록 보안을 유지합니다.
+ *
+ * @returns deviceId - 기존에 저장된 Device ID 또는 새로 생성된 UUID
+ *
+ * @example
+ * ```tsx
+ * const deviceId = await getOrCreateDeviceId();
+ * ```
+ */
+export async function getOrCreateDeviceId(): Promise<string> {
+  const cookieStore = await cookies();
+  let deviceId = cookieStore.get("x-device-id")?.value;
+
+  if (!deviceId) {
+    deviceId = crypto.randomUUID();
+    cookieStore.set("x-device-id", deviceId, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 365, // 1년
+    });
+  }
+
+  return deviceId;
+}

--- a/apps/web/src/domains/auth/index.ts
+++ b/apps/web/src/domains/auth/index.ts
@@ -16,3 +16,6 @@ export const auth = new AuthClient({
     maxAge: SESSION_COOKIE_MAX_AGE,
   },
 });
+
+// Server Actions
+export { getOrCreateDeviceId } from "./actions/get-or-create-device-id";

--- a/apps/web/src/domains/auth/login/ui/components/login-social-buttons/index.tsx
+++ b/apps/web/src/domains/auth/login/ui/components/login-social-buttons/index.tsx
@@ -11,7 +11,7 @@ export const LoginSocialButtons = () => {
       <a href="/api/auth/kakao/login" aria-label="Kakao 계정으로 로그인">
         <KakaoIcon />
       </a>
-      <a href="/login/naver" aria-label="Naver 계정으로 로그인">
+      <a href="/api/auth/naver/login" aria-label="Naver 계정으로 로그인">
         <NaverIcon />
       </a>
     </Flex>

--- a/apps/web/src/domains/auth/providers/base-oauth-provider.ts
+++ b/apps/web/src/domains/auth/providers/base-oauth-provider.ts
@@ -1,0 +1,158 @@
+import type {
+  ExchangeTokenParams,
+  GetAuthorizeUrlParams,
+  OAuthProvider,
+  ProviderType,
+  Session,
+} from "../types";
+import { AuthError } from "../types/errors";
+import { createDeviceInfo } from "../utils/device";
+
+/**
+ * OAuth Provider의 공통 로직을 담은 추상 클래스
+ */
+export abstract class BaseOAuthProvider implements OAuthProvider {
+  abstract readonly type: Exclude<ProviderType, "credentials">;
+
+  /**
+   * 각 Provider의 고유한 인증 URL 요청 API
+   */
+  protected abstract fetchAuthorizeUrl(redirectUri: string): Promise<{
+    status: number;
+    data: { success?: boolean; data?: { authorizeUrl?: string } };
+  }>;
+
+  /**
+   * 각 Provider의 고유한 로그인 API
+   */
+  protected abstract fetchLogin(params: {
+    code: string;
+    redirectUri: string;
+    deviceInfo: ReturnType<typeof createDeviceInfo>;
+  }): Promise<{
+    status: number;
+    data: {
+      success?: boolean;
+      data?: {
+        status?: "NEW_USER" | "EXISTING_USER";
+        registrationToken?: string;
+        userId?: number;
+        nickname?: string;
+        accessToken?: string;
+        refreshToken?: string;
+      };
+    };
+  }>;
+
+  /**
+   * OAuth 인증 URL 생성 (공통 로직)
+   */
+  async getAuthorizeUrl({
+    redirectUri,
+  }: GetAuthorizeUrlParams): Promise<string> {
+    try {
+      const response = await this.fetchAuthorizeUrl(redirectUri);
+
+      if (response.status !== 200 || !response.data.success) {
+        throw AuthError.authorizationFailed(
+          this.type,
+          "Failed to get authorize URL",
+        );
+      }
+
+      const authorizeUrl = response.data.data?.authorizeUrl;
+      if (!authorizeUrl) {
+        throw AuthError.authorizationFailed(
+          this.type,
+          "No authorize URL found",
+        );
+      }
+
+      return authorizeUrl;
+    } catch (error) {
+      if (error instanceof AuthError) throw error;
+      throw AuthError.authorizationFailed(this.type, String(error));
+    }
+  }
+
+  /**
+   * OAuth 토큰 교환 및 세션 생성 (공통 로직)
+   */
+  async exchangeToken({
+    request,
+    redirectUri,
+  }: ExchangeTokenParams): Promise<Session> {
+    try {
+      const code = request.nextUrl.searchParams.get("code");
+      if (!code) {
+        throw AuthError.invalidCallbackCode(this.type);
+      }
+
+      const userAgent = request.headers.get("user-agent") || "Unknown";
+      const deviceInfo = createDeviceInfo(userAgent);
+      const deviceId = deviceInfo.deviceUniqueId;
+
+      const response = await this.fetchLogin({
+        code,
+        redirectUri,
+        deviceInfo,
+      });
+
+      // 신규 회원 (202 ACCEPTED)
+      if (response.data.data?.status === "NEW_USER") {
+        const data = response.data.data;
+        if (!data?.registrationToken) {
+          throw AuthError.tokenExchangeFailed(
+            this.type,
+            "No registration token in response",
+          );
+        }
+
+        // 신규 회원 에러를 던져서 상위에서 회원가입 페이지로 리다이렉트 처리
+        throw AuthError.newUserSignupRequired(
+          this.type,
+          data.registrationToken,
+        );
+      }
+
+      // 기존 회원 (200 OK)
+      if (response.status !== 200 || !response.data.success) {
+        throw AuthError.tokenExchangeFailed(this.type, "Token exchange failed");
+      }
+
+      const data = response.data.data;
+      if (!data) {
+        throw AuthError.tokenExchangeFailed(this.type, "No data in response");
+      }
+
+      // 기존 회원 데이터 검증
+      if (
+        typeof data.userId !== "number" ||
+        typeof data.nickname !== "string" ||
+        typeof data.accessToken !== "string" ||
+        typeof data.refreshToken !== "string"
+      ) {
+        throw AuthError.tokenExchangeFailed(
+          this.type,
+          "Invalid response data types",
+        );
+      }
+
+      return {
+        user: {
+          userId: data.userId,
+          nickname: data.nickname,
+        },
+        tokenSet: {
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken,
+        },
+        provider: this.type,
+        deviceId,
+      };
+    } catch (error) {
+      if (error instanceof AuthError) throw error;
+      throw AuthError.tokenExchangeFailed(this.type, String(error));
+    }
+  }
+}

--- a/apps/web/src/domains/auth/providers/base-oauth-provider.ts
+++ b/apps/web/src/domains/auth/providers/base-oauth-provider.ts
@@ -89,8 +89,10 @@ export abstract class BaseOAuthProvider implements OAuthProvider {
       }
 
       const userAgent = request.headers.get("user-agent") || "Unknown";
-      const deviceInfo = createDeviceInfo(userAgent, request);
-      const deviceId = deviceInfo.deviceUniqueId;
+      // 쿠키에서 기존 Device ID를 가져오거나 새로 생성
+      const deviceId =
+        request.cookies.get("x-device-id")?.value || crypto.randomUUID();
+      const deviceInfo = createDeviceInfo(userAgent, deviceId, request);
 
       const response = await this.fetchLogin({
         code,

--- a/apps/web/src/domains/auth/providers/base-oauth-provider.ts
+++ b/apps/web/src/domains/auth/providers/base-oauth-provider.ts
@@ -89,7 +89,7 @@ export abstract class BaseOAuthProvider implements OAuthProvider {
       }
 
       const userAgent = request.headers.get("user-agent") || "Unknown";
-      const deviceInfo = createDeviceInfo(userAgent);
+      const deviceInfo = createDeviceInfo(userAgent, request);
       const deviceId = deviceInfo.deviceUniqueId;
 
       const response = await this.fetchLogin({

--- a/apps/web/src/domains/auth/providers/kakao-provider.ts
+++ b/apps/web/src/domains/auth/providers/kakao-provider.ts
@@ -1,118 +1,19 @@
 import { getKakaoAuthorizeUrl, kakaoLogin } from "@nugudi/api";
-import type {
-  ExchangeTokenParams,
-  GetAuthorizeUrlParams,
-  OAuthProvider,
-  Session,
-} from "../types";
-import { AuthError } from "../types/errors";
-import { createDeviceInfo } from "../utils/device";
+import type { createDeviceInfo } from "../utils/device";
+import { BaseOAuthProvider } from "./base-oauth-provider";
 
-export class KakaoProvider implements OAuthProvider {
+export class KakaoProvider extends BaseOAuthProvider {
   readonly type = "kakao" as const;
 
-  async getAuthorizeUrl({
-    redirectUri,
-  }: GetAuthorizeUrlParams): Promise<string> {
-    try {
-      const response = await getKakaoAuthorizeUrl({
-        redirectUri,
-      });
-
-      if (response.status !== 200 || !response.data.success) {
-        throw AuthError.authorizationFailed(
-          "kakao",
-          "Failed to get authorize URL",
-        );
-      }
-
-      const authorizeUrl = response.data.data?.authorizeUrl;
-      if (!authorizeUrl) {
-        throw AuthError.authorizationFailed("kakao", "No authorize URL found");
-      }
-
-      return authorizeUrl;
-    } catch (error) {
-      if (error instanceof AuthError) throw error;
-      throw AuthError.authorizationFailed("kakao", String(error));
-    }
+  protected async fetchAuthorizeUrl(redirectUri: string) {
+    return getKakaoAuthorizeUrl({ redirectUri });
   }
 
-  /**
-   * 카카오 OAuth 토큰 교환 및 세션 생성
-   */
-  async exchangeToken({
-    request,
-    redirectUri,
-  }: ExchangeTokenParams): Promise<Session> {
-    try {
-      const code = request.nextUrl.searchParams.get("code");
-      if (!code) {
-        throw AuthError.invalidCallbackCode("kakao");
-      }
-
-      const userAgent = request.headers.get("user-agent") || "Unknown";
-      const deviceInfo = createDeviceInfo(userAgent);
-      const deviceId = deviceInfo.deviceUniqueId;
-
-      const response = await kakaoLogin({
-        code,
-        redirectUri,
-        deviceInfo,
-      });
-
-      // 신규 회원 (202 ACCEPTED)
-      if (response.data.data?.status === "NEW_USER") {
-        const data = response.data.data;
-        if (!data?.registrationToken) {
-          throw AuthError.tokenExchangeFailed(
-            "kakao",
-            "No registration token in response",
-          );
-        }
-
-        // 신규 회원 에러를 던져서 상위에서 회원가입 페이지로 리다이렉트 처리
-        throw AuthError.newUserSignupRequired("kakao", data.registrationToken);
-      }
-
-      // 기존 회원 (200 OK)
-      if (response.status !== 200 || !response.data.success) {
-        throw AuthError.tokenExchangeFailed("kakao", "Token exchange failed");
-      }
-
-      const data = response.data.data;
-      if (!data) {
-        throw AuthError.tokenExchangeFailed("kakao", "No data in response");
-      }
-
-      // 기존 회원 데이터 검증
-      if (
-        typeof data.userId !== "number" ||
-        typeof data.nickname !== "string" ||
-        typeof data.accessToken !== "string" ||
-        typeof data.refreshToken !== "string"
-      ) {
-        throw AuthError.tokenExchangeFailed(
-          "kakao",
-          "Invalid response data types",
-        );
-      }
-
-      return {
-        user: {
-          userId: data.userId,
-          nickname: data.nickname,
-        },
-        tokenSet: {
-          accessToken: data.accessToken,
-          refreshToken: data.refreshToken,
-        },
-        provider: "kakao",
-        deviceId,
-      };
-    } catch (error) {
-      if (error instanceof AuthError) throw error;
-      throw AuthError.tokenExchangeFailed("kakao", String(error));
-    }
+  protected async fetchLogin(params: {
+    code: string;
+    redirectUri: string;
+    deviceInfo: ReturnType<typeof createDeviceInfo>;
+  }) {
+    return kakaoLogin(params);
   }
 }

--- a/apps/web/src/domains/auth/providers/naver-provider.ts
+++ b/apps/web/src/domains/auth/providers/naver-provider.ts
@@ -1,12 +1,12 @@
-import { getGoogleAuthorizeUrl, googleLogin } from "@nugudi/api";
+import { getNaverAuthorizeUrl, naverLogin } from "@nugudi/api";
 import type { createDeviceInfo } from "../utils/device";
 import { BaseOAuthProvider } from "./base-oauth-provider";
 
-export class GoogleProvider extends BaseOAuthProvider {
-  readonly type = "google" as const;
+export class NaverProvider extends BaseOAuthProvider {
+  readonly type = "naver" as const;
 
   protected async fetchAuthorizeUrl(redirectUri: string) {
-    return getGoogleAuthorizeUrl({ redirectUri });
+    return getNaverAuthorizeUrl({ redirectUri });
   }
 
   protected async fetchLogin(params: {
@@ -14,6 +14,6 @@ export class GoogleProvider extends BaseOAuthProvider {
     redirectUri: string;
     deviceInfo: ReturnType<typeof createDeviceInfo>;
   }) {
-    return googleLogin(params);
+    return naverLogin(params);
   }
 }

--- a/apps/web/src/domains/auth/social-sign-up/hooks/use-social-sign-up-submit.ts
+++ b/apps/web/src/domains/auth/social-sign-up/hooks/use-social-sign-up-submit.ts
@@ -2,6 +2,7 @@ import { signUpSocial } from "@nugudi/api";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { logger } from "@/src/lib/logger";
+import { getOrCreateDeviceId } from "../../actions/get-or-create-device-id";
 import { AuthError } from "../../types/errors";
 import { createDeviceInfo } from "../../utils/device";
 import { SOCIAL_SIGN_UP_STORE_KEY } from "../constants/social-sign-up";
@@ -63,8 +64,9 @@ export const useSocialSignUpSubmit = () => {
         throw AuthError.missingRequiredFields(["registrationToken"]);
       }
 
-      // 1. Device info 생성 (쿠키에서 기존 device ID를 가져오거나 새로 생성)
-      const deviceInfo = createDeviceInfo(navigator.userAgent);
+      // 1. Device ID를 Server Action을 통해 가져오기 (httpOnly 쿠키에서 안전하게 관리)
+      const deviceId = await getOrCreateDeviceId();
+      const deviceInfo = createDeviceInfo(navigator.userAgent, deviceId);
 
       // 2. 소셜 회원가입 API 호출
       const response = await signUpSocial(

--- a/apps/web/src/domains/auth/social-sign-up/hooks/use-social-sign-up-submit.ts
+++ b/apps/web/src/domains/auth/social-sign-up/hooks/use-social-sign-up-submit.ts
@@ -50,8 +50,6 @@ export const useSocialSignUpSubmit = () => {
     setIsSubmitting(true);
 
     try {
-      const deviceInfo = createDeviceInfo(navigator.userAgent);
-
       logger.info("Starting social sign up", {
         provider,
         nickname: data.nickname,
@@ -65,7 +63,10 @@ export const useSocialSignUpSubmit = () => {
         throw AuthError.missingRequiredFields(["registrationToken"]);
       }
 
-      // 1. 소셜 회원가입 API 호출
+      // 1. Device info 생성 (쿠키에서 기존 device ID를 가져오거나 새로 생성)
+      const deviceInfo = createDeviceInfo(navigator.userAgent);
+
+      // 2. 소셜 회원가입 API 호출
       const response = await signUpSocial(
         {
           nickname: data.nickname,
@@ -108,6 +109,7 @@ export const useSocialSignUpSubmit = () => {
       });
 
       // 3. 세션 설정을 위해 내부 API 호출
+      // deviceId는 서버에서 쿠키를 통해 재사용하되, 클라이언트에서 생성한 ID도 전달
       const sessionResponse = await fetch("/api/auth/sign-up/social", {
         method: "POST",
         headers: {

--- a/apps/web/src/domains/auth/types/registry.ts
+++ b/apps/web/src/domains/auth/types/registry.ts
@@ -1,5 +1,6 @@
 import { GoogleProvider } from "../providers/google-provider";
 import { KakaoProvider } from "../providers/kakao-provider";
+import { NaverProvider } from "../providers/naver-provider";
 import { AuthError } from "./errors";
 import type { Provider, ProviderRegistry, ProviderType } from "./provider";
 
@@ -9,6 +10,7 @@ class ProviderRegistryImplements {
   constructor() {
     this.registerProvider(new KakaoProvider());
     this.registerProvider(new GoogleProvider());
+    this.registerProvider(new NaverProvider());
   }
 
   /**

--- a/apps/web/src/domains/auth/utils/auth-client.ts
+++ b/apps/web/src/domains/auth/utils/auth-client.ts
@@ -161,6 +161,16 @@ export class AuthClient {
       encrypted,
       this.config.cookieOptions,
     );
+
+    // Device ID를 별도 쿠키로 저장하여 재사용 가능하도록 함
+    if (session.deviceId) {
+      cookieStore.set("x-device-id", session.deviceId, {
+        ...this.config.cookieOptions,
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+      });
+    }
   }
 
   /**

--- a/apps/web/src/domains/auth/utils/device.ts
+++ b/apps/web/src/domains/auth/utils/device.ts
@@ -1,10 +1,26 @@
 import type { UserDeviceInfoDTO } from "@nugudi/api/schemas";
+import type { NextRequest } from "next/server";
 import { UAParser } from "ua-parser-js";
 
 /**
- * User Agent를 파싱하여 디바이스 정보 생성
+ * 브라우저 쿠키에서 특정 값 읽기
  */
-export const createDeviceInfo = (userAgent: string): UserDeviceInfoDTO => {
+const getCookieValue = (name: string): string | undefined => {
+  if (typeof document === "undefined") return undefined;
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(";").shift();
+  return undefined;
+};
+
+/**
+ * User Agent를 파싱하여 디바이스 정보 생성
+ * 쿠키에 저장된 기존 device ID가 있으면 재사용하고, 없으면 새로 생성
+ */
+export const createDeviceInfo = (
+  userAgent: string,
+  request?: NextRequest,
+): UserDeviceInfoDTO => {
   const parser = new UAParser(userAgent);
   const device = parser.getDevice();
   const os = parser.getOS();
@@ -16,9 +32,16 @@ export const createDeviceInfo = (userAgent: string): UserDeviceInfoDTO => {
     deviceType = "ANDROID";
   }
 
+  // 쿠키에서 기존 device ID 조회
+  // 서버: NextRequest에서 쿠키 읽기
+  // 클라이언트: document.cookie에서 쿠키 읽기
+  const existingDeviceId =
+    request?.cookies.get("x-device-id")?.value || getCookieValue("x-device-id");
+  const deviceUniqueId = existingDeviceId || crypto.randomUUID();
+
   return {
     deviceType,
-    deviceUniqueId: crypto.randomUUID(),
+    deviceUniqueId,
     deviceName:
       device.model || device.vendor || `${os.name || "Unknown"} Device`,
     deviceModel: device.model || "Unknown",


### PR DESCRIPTION
## 🌀 Issue Number
- #183 
<!-- #이슈번호 -->

## 😵 As-Is
  - 카카오, 구글 소셜 로그인만 지원
  - Provider별 중복 코드 존재 (OAuth 인증 URL 생성, 토큰 교환 로직 반복)
  - 콜백 라우트가 Provider별로 개별 파일로 관리됨
  - 회원가입 폼에서 비즈니스 로직과 UI가 혼재
<!-- 문제 상황 정의 -->

## 🥳 To-Be
  - 네이버, 구글 소셜 로그인 추가 지원
  - `BaseOAuthProvider` 추상 클래스로 공통 로직 분리 (DRY 원칙 준수)
  - 콜백 라우트를 `/api/auth/callback/[provider]`로 통합
  - 회원가입 로직을 `useSocialSignUpSubmit` 훅으로 분리하여 재사용성 향상
  - 구조화된 에러 처리 추가 (`AuthError` 확장)
<!-- 변경 사항 -->

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?

## 📷 Test Screenshot (Optional)

## 👾 Additional Description (Optional)
주요 변경 사항
  - `base-oauth-provider.ts`: OAuth 공통 로직 (인증 URL 생성, 토큰 교환)
  - `google-provider.ts`, `naver-provider.ts`: Google, Naver Provider 구현
  - `/api/auth/callback/[provider]/route.ts`: Provider 통합 콜백 라우트
  - `/api/auth/sign-up/social/route.ts`: 소셜 회원가입 세션 설정 API
  - `use-social-sign-up-submit.ts`: 회원가입 제출 로직 훅으로 분리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 네이버 소셜 로그인을 추가 지원합니다.
  - 기기 식별자(deviceId)를 별도 쿠키로 저장해 기기 재사용을 지원합니다.
  - 소셜 가입/로그인 시 기기 정보(deviceInfo)를 서버로 전송하도록 개선했습니다.

- 버그 수정
  - 네이버 로그인 버튼의 링크를 올바른 인증 경로로 수정했습니다.

- 리팩터링
  - 소셜 OAuth 흐름을 공통화해 인증 안정성과 오류 처리를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->